### PR TITLE
Add support for anttask p2.mirror slicingOptions

### DIFF
--- a/src/main/java/com/diffplug/gradle/p2/P2Declarative.java
+++ b/src/main/java/com/diffplug/gradle/p2/P2Declarative.java
@@ -74,6 +74,10 @@ public interface P2Declarative {
 		getP2().addFeature(feature, version);
 	}
 
+	default void slicingOption(String option, String value) {
+		getP2().addSlicingOption(option, value);
+	}
+
 	public static void populate(P2Model model, Action<P2Declarative> action) {
 		action.execute(new P2Declarative() {
 			@Override

--- a/src/main/java/com/diffplug/gradle/p2/P2Model.java
+++ b/src/main/java/com/diffplug/gradle/p2/P2Model.java
@@ -259,7 +259,7 @@ public class P2Model implements Serializable {
 					}
 				}
 
-				if(slicingOptions.size() > 0) {
+				if (slicingOptions.size() > 0) {
 					slicingOptionsNode(taskNode);
 				}
 			});

--- a/src/main/java/com/diffplug/gradle/p2/P2Model.java
+++ b/src/main/java/com/diffplug/gradle/p2/P2Model.java
@@ -259,7 +259,9 @@ public class P2Model implements Serializable {
 					}
 				}
 
-				slicingOptionsNode(taskNode);
+				if(slicingOptions.size() > 0) {
+					slicingOptionsNode(taskNode);
+				}
 			});
 		});
 	}
@@ -283,7 +285,6 @@ public class P2Model implements Serializable {
 
 	/** Creates an XML node for slicingOptions. */
 	private Node slicingOptionsNode(Node parent) {
-
 		Node slicingOptionsNode = new Node(parent, "slicingOptions");
 		for (Map.Entry<String, String> option : slicingOptions.entrySet()) {
 			slicingOptionsNode.attributes().put(option.getKey(), option.getValue());

--- a/src/main/java/com/diffplug/gradle/p2/P2Model.java
+++ b/src/main/java/com/diffplug/gradle/p2/P2Model.java
@@ -18,12 +18,7 @@ package com.diffplug.gradle.p2;
 import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -67,12 +62,14 @@ public class P2Model implements Serializable {
 		repos.addAll(other.repos);
 		metadataRepos.addAll(other.metadataRepos);
 		artifactRepos.addAll(other.artifactRepos);
+		slicingOptions.putAll(other.slicingOptions);
 	}
 
 	private Set<String> ius = new LinkedHashSet<>();
 	private Set<String> repos = new LinkedHashSet<>();
 	private Set<String> metadataRepos = new LinkedHashSet<>();
 	private Set<String> artifactRepos = new LinkedHashSet<>();
+	private Map<String, String> slicingOptions = new HashMap<>();
 
 	/** Combines all fields for easy implementation of equals and hashCode. */
 	private final List<Object> content = Arrays.asList(ius, repos, metadataRepos, artifactRepos);
@@ -163,6 +160,10 @@ public class P2Model implements Serializable {
 
 	public void addArtifactRepoBundlePool() {
 		addArtifactRepo(GoomphCacheLocations.bundlePool());
+	}
+
+	public void addSlicingOption(String option, String value) {
+		slicingOptions.put(option, value);
 	}
 
 	/**
@@ -257,6 +258,8 @@ public class P2Model implements Serializable {
 						iuNode.attributes().put("version", iu.substring(slash + 1));
 					}
 				}
+
+				slicingOptionsNode(taskNode);
 			});
 		});
 	}
@@ -276,6 +279,16 @@ public class P2Model implements Serializable {
 		addRepos.accept(metadataRepos, repoAttr -> repoAttr.put("kind", "metadata"));
 		addRepos.accept(artifactRepos, repoAttr -> repoAttr.put("kind", "artifact"));
 		return source;
+	}
+
+	/** Creates an XML node for slicingOptions. */
+	private Node slicingOptionsNode(Node parent) {
+
+		Node slicingOptionsNode = new Node(parent, "slicingOptions");
+		for (Map.Entry<String, String> option : slicingOptions.entrySet()) {
+			slicingOptionsNode.attributes().put(option.getKey(), option.getValue());
+		}
+		return slicingOptionsNode;
 	}
 
 	////////////////

--- a/src/test/java/com/diffplug/gradle/p2/P2ModelTest.java
+++ b/src/test/java/com/diffplug/gradle/p2/P2ModelTest.java
@@ -74,4 +74,33 @@ public class P2ModelTest {
 				"</project>");
 		Assert.assertEquals(expected, actual);
 	}
+
+	@Test
+	public void testMirrorAntFileWithSlicingOptions() {
+		File dest = new File("dest");
+		P2Model p2 = testData();
+		p2.addSlicingOption("latestVersionOnly", "true");
+		p2.addSlicingOption("platformfilter", "win32,win32,x86");
+		p2.addSlicingOption("filter", "key=value");
+		String actual = p2.mirrorApp(dest).completeState();
+		String expected = StringPrinter.buildStringFromLines(
+				"### ARGS ###",
+				"-application org.eclipse.ant.core.antRunner",
+				"",
+				"### BUILD.XML ###",
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?><project>",
+				"  <p2.mirror>",
+				"    <source>",
+				"      <repository location=\"http://p2repo\"/>",
+				"      <repository kind=\"metadata\" location=\"http://metadatarepo\"/>",
+				"      <repository kind=\"artifact\" location=\"http://artifactrepo\"/>",
+				"    </source>",
+				"    <destination location=\"" + FileMisc.asUrl(dest) + "\"/>",
+				"    <iu id=\"com.diffplug.iu\"/>",
+				"    <iu id=\"com.diffplug.otheriu\" version=\"1.0.0\"/>",
+				"    <slicingOptions filter=\"key=value\" latestVersionOnly=\"true\" platformfilter=\"win32,win32,x86\"/>",
+				"  </p2.mirror>",
+				"</project>");
+		Assert.assertEquals(expected, actual);
+	}
 }


### PR DESCRIPTION
https://wiki.eclipse.org/Equinox/p2/Ant_Tasks#SlicingOptions
e.g. setting 'latestVersionOnly' flag to reduce multiple versions for single dependencies

usage example:

```
p2AsMaven {
    group 'eclipse-deps', {
        repoEclipse '3.8.2'
        repo 'http://download.eclipse.org/releases/juno/'
        iu 'org.eclipse.core.jobs'
        slicingOption 'latestVersionOnly', 'true'
        repo2runnable()
    }
}
```
