### PR TITLE
Added InputStreamCollector

### DIFF
--- a/src/main/java/com/diffplug/gradle/CmdLine.java
+++ b/src/main/java/com/diffplug/gradle/CmdLine.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.management.RuntimeErrorException;
+
 import org.apache.commons.io.FileUtils;
 
 import com.diffplug.common.base.Throwing;
@@ -157,9 +159,9 @@ public class CmdLine {
 			stdErrorThread.join();
 
 			if (stdInputThread.getException() != null) {
-				throw stdInputThread.getException();
+				throw new RuntimeException(stdInputThread.getException());
 			} else if (stdErrorThread.getException() != null) {
-				throw stdErrorThread.getException();
+				throw new RuntimeException(stdErrorThread.getException());
 			} else if (exitValue != EXIT_VALUE_SUCCESS) {
 				throw new RuntimeException("'" + cmd + "' exited with " + exitValue);
 			}

--- a/src/main/java/com/diffplug/gradle/CmdLine.java
+++ b/src/main/java/com/diffplug/gradle/CmdLine.java
@@ -15,11 +15,8 @@
  */
 package com.diffplug.gradle;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -143,42 +140,32 @@ public class CmdLine {
 		Process process = builder.start();
 
 		// wrap the process' input and output
-		try (
-				BufferedReader stdInput = new BufferedReader(new InputStreamReader(process.getInputStream(), Charset.defaultCharset()));
-				BufferedReader stdError = new BufferedReader(new InputStreamReader(process.getErrorStream(), Charset.defaultCharset()));) {
-
+		try {
 			if (echoCmd) {
 				System.out.println("cmd>" + cmd);
 			}
 
-			// dump the output
-			ImmutableList.Builder<String> output = ImmutableList.builder();
-			ImmutableList.Builder<String> error = ImmutableList.builder();
-
-			String line = null;
-			while ((line = stdInput.readLine()) != null) {
-				output.add(line);
-				if (echoOutput) {
-					System.out.println(line);
-				}
-			}
-
-			// dump the input
-			while ((line = stdError.readLine()) != null) {
-				error.add(line);
-				if (echoOutput) {
-					System.err.println(line);
-				}
-			}
+			InputStreamCollector stdInputThread = new InputStreamCollector(process.getInputStream(), echoOutput ? System.out : null, null);
+			stdInputThread.start();
+			InputStreamCollector stdErrorThread = new InputStreamCollector(process.getErrorStream(), echoOutput ? System.err : null, null);
+			stdErrorThread.start();
 
 			// check that the process exited correctly
 			int exitValue = process.waitFor();
-			if (exitValue != EXIT_VALUE_SUCCESS) {
+			// then wait for threads collecting the output of thread
+			stdInputThread.join();
+			stdErrorThread.join();
+
+			if (stdInputThread.getException() != null) {
+				throw stdInputThread.getException();
+			} else if (stdErrorThread.getException() != null) {
+				throw stdErrorThread.getException();
+			} else if (exitValue != EXIT_VALUE_SUCCESS) {
 				throw new RuntimeException("'" + cmd + "' exited with " + exitValue);
 			}
 
 			// returns the result of this successful execution
-			return new Result(directory, cmd, output.build(), error.build());
+			return new Result(directory, cmd, stdInputThread.getOutput(), stdErrorThread.getOutput());
 		} catch (InterruptedException e) {
 			// this isn't expected, but it's possible
 			throw new RuntimeException(e);

--- a/src/main/java/com/diffplug/gradle/InputStreamCollector.java
+++ b/src/main/java/com/diffplug/gradle/InputStreamCollector.java
@@ -40,7 +40,7 @@ public class InputStreamCollector extends Thread {
 
 	private volatile IOException exception;
 
-	public InputStreamCollector(@Nonnull InputStream is, @Nullable PrintStream ps, @Nullable Charset cs) {
+	public InputStreamCollector(InputStream is, @Nullable PrintStream ps, @Nullable Charset cs) {
 		this.iStream = Objects.requireNonNull(is);
 		this.pStream = ps;
 		this.charset = cs != null ? cs : Charset.defaultCharset();

--- a/src/main/java/com/diffplug/gradle/InputStreamCollector.java
+++ b/src/main/java/com/diffplug/gradle/InputStreamCollector.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.diffplug.common.collect.ImmutableList;
+
+public class InputStreamCollector extends Thread {
+
+	private final InputStream iStream;
+
+	private final PrintStream pStream;
+
+	private final Charset charset;
+
+	private final ImmutableList.Builder<String> output;
+
+	private volatile IOException exception;
+
+	public InputStreamCollector(@Nonnull InputStream is, @Nullable PrintStream ps, @Nullable Charset cs) {
+		this.iStream = Objects.requireNonNull(is);
+		this.pStream = ps;
+		this.charset = cs != null ? cs : Charset.defaultCharset();
+		this.output = ImmutableList.builder();
+	}
+
+	@Override
+	public void run() {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(iStream, charset))) {
+			String line = null;
+			while ((line = reader.readLine()) != null) {
+				output.add(line);
+				if (pStream != null) {
+					pStream.println(line);
+				}
+			}
+		} catch (IOException ex) {
+			this.exception = ex;
+		}
+	}
+
+	public ImmutableList<String> getOutput() {
+		return output.build();
+	}
+
+	public IOException getException() {
+		return exception;
+	}
+
+}


### PR DESCRIPTION
Multithreaded way to collect inputStreams of started process in order to prevent deadlocks when buffer for StdErr is full while parent process still tries to read from StdOut.