### PR TITLE
Add PDE bootstrap url override feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.10.0 - TBD ([javadoc](http://diffplug.github.io/goomph/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/gradle/goomph/))
 
+- Added a feature to provide a custom goomph-pde-bootstrap installation. [(#49)](https://github.com/diffplug/goomph/pull/52)
+
 ### Version 3.9.1 - February 2nd 2018 ([javadoc](http://diffplug.github.io/goomph/javadoc/3.9.1/), [jcenter](https://bintray.com/diffplug/opensource/goomph/3.9.1/view))
 
 - Added `--launcher.suppressErrors` to all `EclipseApp` invocations so that build errors won't open a blocking dialog on build servers. [(#49)](https://github.com/diffplug/goomph/pull/49)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Version 3.10.0 - TBD ([javadoc](http://diffplug.github.io/goomph/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/gradle/goomph/))
 
-- Added a feature to provide a custom goomph-pde-bootstrap installation. [(#49)](https://github.com/diffplug/goomph/pull/52)
+- Added a feature to provide a custom goomph-pde-bootstrap installation. [(#52)](https://github.com/diffplug/goomph/pull/52)
 
 ### Version 3.9.1 - February 2nd 2018 ([javadoc](http://diffplug.github.io/goomph/javadoc/3.9.1/), [jcenter](https://bintray.com/diffplug/opensource/goomph/3.9.1/view))
 

--- a/src/main/java/com/diffplug/gradle/GoomphCacheLocations.java
+++ b/src/main/java/com/diffplug/gradle/GoomphCacheLocations.java
@@ -36,6 +36,7 @@ import com.diffplug.gradle.p2.P2Model;
  *
  * - {@link #p2bootstrap()}
  * - {@link #pdeBootstrap()}
+ * - {@link #pdeBootstrapUrl()}
  * - {@link #bundlePool()}
  * - {@link #workspaces()}
  *
@@ -120,6 +121,26 @@ public class GoomphCacheLocations {
 	}
 
 	public static File override_p2bootstrap = null;
+
+	/**
+	 * Location where the pde-bootstrap application should be downloaded from.
+	 *
+	 * Goomph's pde tasks rely on the eclipse [p2 director application](http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_director.html&cp=2_0_20_2).
+	 * It is distributed within the Eclipse SDK.  The Package is
+	 * downloaded and installed during configuration from official eclipse
+	 * repository.
+	 *
+	 * Defaults to official update site of the selected Eclipse Release.  If you override, it still
+	 * needs to follow the correct versioning scheme.  e.g. if you want to relocate to `http://intranet/goomph-pde-boostrap`, then
+	 * the artifact will need to be available at `http://intranet/goomph-pde-boostrap/4.5.2/goomph-pde-bootstrap.zip`
+	 *
+	 * As new versions of pdeBootstrap come out, you will have to update your internal URL cache, but these releases are infrequent.
+	 */
+	public static Optional<String> pdeBootstrapUrl() {
+		return Optional.ofNullable(override_pdeBootstrapUrl);
+	}
+
+	public static String override_pdeBootstrapUrl = null;
 
 	/**
 	 * Location where eclipse instances with PDE build

--- a/src/main/java/com/diffplug/gradle/pde/PdeInstallation.java
+++ b/src/main/java/com/diffplug/gradle/pde/PdeInstallation.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.diffplug.gradle.ZipMisc;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Project;
 import org.osgi.framework.Version;
@@ -37,6 +36,7 @@ import com.diffplug.common.swt.os.OS;
 import com.diffplug.common.swt.os.SwtPlatform;
 import com.diffplug.gradle.FileMisc;
 import com.diffplug.gradle.GoomphCacheLocations;
+import com.diffplug.gradle.ZipMisc;
 import com.diffplug.gradle.eclipserunner.EclipseApp;
 import com.diffplug.gradle.eclipserunner.EclipseRunner;
 import com.diffplug.gradle.eclipserunner.NativeRunner;
@@ -165,24 +165,24 @@ public class PdeInstallation implements EclipseRunner {
 	/** Installs the bootstrap installation. */
 	private void install() throws Exception {
 
-		if(GoomphCacheLocations.pdeBootstrapUrl().isPresent()) {
+		if (GoomphCacheLocations.pdeBootstrapUrl().isPresent()) {
 			String url = GoomphCacheLocations.pdeBootstrapUrl().get();
 			System.out.print("Installing pde " + release + " from " + url + "... ");
-            File target = new File(getRootFolder(), DOWNLOAD_FILE);
+			File target = new File(getRootFolder(), DOWNLOAD_FILE);
 			try {
 				obtainBootstrap(url + release.version() + DOWNLOAD_FILE, target);
 			} catch (FileNotFoundException ex) {
 				//try versioned artifact - Common when bootstrap is on a maven type(sonatype nexus, etc.) repository.
 				obtainBootstrap(url + release.version() + String.format(VERSIONED_DOWNLOAD_FILE, release.version()), target);
 			}
-            // unzip it
-            ZipMisc.unzip(target, target.getParentFile());
-            // delete the zip
-            FileMisc.forceDelete(target);
-        } else {
+			// unzip it
+			ZipMisc.unzip(target, target.getParentFile());
+			// delete the zip
+			FileMisc.forceDelete(target);
+		} else {
 			System.out.print("Installing pde " + release + "... ");
-		    obtainBootstrap(release);
-        }
+			obtainBootstrap(release);
+		}
 
 		// parse out the pde.build version
 		File bundleInfo = new File(getContentsEclipse(), "configuration/org.eclipse.equinox.simpleconfigurator/bundles.info");
@@ -196,20 +196,20 @@ public class PdeInstallation implements EclipseRunner {
 	}
 
 	/** Obtain PDE Installation from custom file or url */
-    private void obtainBootstrap(String bootstrapUrl, File target) throws IOException {
-        URL url = new URL(bootstrapUrl);
-        FileUtils.copyURLToFile(url, target);
-    }
+	private void obtainBootstrap(String bootstrapUrl, File target) throws IOException {
+		URL url = new URL(bootstrapUrl);
+		FileUtils.copyURLToFile(url, target);
+	}
 
-    /** Obtain PDE Installation from remote p2 repository */
+	/** Obtain PDE Installation from remote p2 repository */
 	private void obtainBootstrap(EclipseRelease release) throws Exception {
-        P2Model.DirectorApp directorApp = p2model().directorApp(getRootFolder(), "goomph-pde-bootstrap-" + release);
-        // share the install for quickness
-        directorApp.bundlepool(GoomphCacheLocations.bundlePool());
-        // create a native launcher
-        directorApp.platform(SwtPlatform.getRunning());
-        directorApp.runUsingBootstrapper();
-    }
+		P2Model.DirectorApp directorApp = p2model().directorApp(getRootFolder(), "goomph-pde-bootstrap-" + release);
+		// share the install for quickness
+		directorApp.bundlepool(GoomphCacheLocations.bundlePool());
+		// create a native launcher
+		directorApp.platform(SwtPlatform.getRunning());
+		directorApp.runUsingBootstrapper();
+	}
 
 	/** Returns the Contents/Eclipse folder on mac, or just the root folder on other OSes. */
 	private File getContentsEclipse() {

--- a/src/main/java/com/diffplug/gradle/pde/PdeInstallation.java
+++ b/src/main/java/com/diffplug/gradle/pde/PdeInstallation.java
@@ -16,13 +16,16 @@
 package com.diffplug.gradle.pde;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.diffplug.gradle.ZipMisc;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Project;
 import org.osgi.framework.Version;
@@ -41,9 +44,13 @@ import com.diffplug.gradle.p2.P2Model;
 
 /** Wraps a PDE installation for the given eclipse release.*/
 public class PdeInstallation implements EclipseRunner {
+
+	static final String DOWNLOAD_FILE = "/goomph-pde-bootstrap.zip";
+	static final String VERSIONED_DOWNLOAD_FILE = "/goomph-pde-bootstrap-%s.zip";
+
 	/**
 	 * Returns a PdeInstallation based on `GOOMPH_PDE_VER`, and other factors.
-	 * 
+	 *
 	 * You must specify which version of Eclipse should be used by Goomph.
 	 * - Option #1: To use an officially supported release, use this:
 	 *     + `GOOMPH_PDE_VER`=4.5.2 (or any official release)
@@ -51,7 +58,7 @@ public class PdeInstallation implements EclipseRunner {
 	 *     + `GOOMPH_PDE_VER`=<any version>
 	 *     + `GOOMPH_PDE_UDPATE_SITE`=<url to update site>
 	 *     + `GOOMPH_PDE_ID`=<the ID used for caching, cannot be a version listed in Option #1)
-	 * 
+	 *
 	 * You must do one or the other, specify only `VER` for Option #1,
 	 * or specify `VER`, `UPDATE_SITE`, and `ID` for Option #2.
 	 */
@@ -133,7 +140,7 @@ public class PdeInstallation implements EclipseRunner {
 
 	/**
 	 * The "org.eclipse.pde.build" folder for this installation.
-	 * 
+	 *
 	 * Set when install() succeeds and when isInstalled() returns true, so it is
 	 * guaranteed to be set when ensureInstalled completes.
 	 */
@@ -157,13 +164,26 @@ public class PdeInstallation implements EclipseRunner {
 
 	/** Installs the bootstrap installation. */
 	private void install() throws Exception {
-		System.out.print("Installing pde " + release + "... ");
-		P2Model.DirectorApp directorApp = p2model().directorApp(getRootFolder(), "goomph-pde-bootstrap-" + release);
-		// share the install for quickness
-		directorApp.bundlepool(GoomphCacheLocations.bundlePool());
-		// create a native launcher
-		directorApp.platform(SwtPlatform.getRunning());
-		directorApp.runUsingBootstrapper();
+
+		if(GoomphCacheLocations.pdeBootstrapUrl().isPresent()) {
+			String url = GoomphCacheLocations.pdeBootstrapUrl().get();
+			System.out.print("Installing pde " + release + " from " + url + "... ");
+            File target = new File(getRootFolder(), DOWNLOAD_FILE);
+			try {
+				obtainBootstrap(url + release.version() + DOWNLOAD_FILE, target);
+			} catch (FileNotFoundException ex) {
+				//try versioned artifact - Common when bootstrap is on a maven type(sonatype nexus, etc.) repository.
+				obtainBootstrap(url + release.version() + String.format(VERSIONED_DOWNLOAD_FILE, release.version()), target);
+			}
+            // unzip it
+            ZipMisc.unzip(target, target.getParentFile());
+            // delete the zip
+            FileMisc.forceDelete(target);
+        } else {
+			System.out.print("Installing pde " + release + "... ");
+		    obtainBootstrap(release);
+        }
+
 		// parse out the pde.build version
 		File bundleInfo = new File(getContentsEclipse(), "configuration/org.eclipse.equinox.simpleconfigurator/bundles.info");
 		Preconditions.checkArgument(bundleInfo.isFile(), "Needed to find the pde.build folder: %s", bundleInfo);
@@ -174,6 +194,22 @@ public class PdeInstallation implements EclipseRunner {
 		FileMisc.writeToken(getRootFolder(), TOKEN, pdeBuildFolder.getAbsolutePath());
 		System.out.println("Success.");
 	}
+
+	/** Obtain PDE Installation from custom file or url */
+    private void obtainBootstrap(String bootstrapUrl, File target) throws IOException {
+        URL url = new URL(bootstrapUrl);
+        FileUtils.copyURLToFile(url, target);
+    }
+
+    /** Obtain PDE Installation from remote p2 repository */
+	private void obtainBootstrap(EclipseRelease release) throws Exception {
+        P2Model.DirectorApp directorApp = p2model().directorApp(getRootFolder(), "goomph-pde-bootstrap-" + release);
+        // share the install for quickness
+        directorApp.bundlepool(GoomphCacheLocations.bundlePool());
+        // create a native launcher
+        directorApp.platform(SwtPlatform.getRunning());
+        directorApp.runUsingBootstrapper();
+    }
 
 	/** Returns the Contents/Eclipse folder on mac, or just the root folder on other OSes. */
 	private File getContentsEclipse() {

--- a/src/test/java/com/diffplug/gradle/pde/PdeBootstrapInstallationCreate.java
+++ b/src/test/java/com/diffplug/gradle/pde/PdeBootstrapInstallationCreate.java
@@ -15,13 +15,12 @@
  */
 package com.diffplug.gradle.pde;
 
-import com.diffplug.gradle.FileMisc;
-import com.diffplug.gradle.p2.P2Model;
-import com.diffplug.gradle.pde.EclipseRelease;
-import com.diffplug.gradle.pde.PdeInstallation;
+import java.io.File;
+
 import org.gradle.internal.impldep.com.google.common.base.StandardSystemProperty;
 
-import java.io.File;
+import com.diffplug.gradle.FileMisc;
+import com.diffplug.gradle.p2.P2Model;
 
 /** Creates a new folder for goomph-pde-bootstrap. */
 public class PdeBootstrapInstallationCreate {

--- a/src/test/java/com/diffplug/gradle/pde/PdeBootstrapInstallationCreate.java
+++ b/src/test/java/com/diffplug/gradle/pde/PdeBootstrapInstallationCreate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.pde;
+
+import com.diffplug.gradle.FileMisc;
+import com.diffplug.gradle.p2.P2Model;
+import com.diffplug.gradle.pde.EclipseRelease;
+import com.diffplug.gradle.pde.PdeInstallation;
+import org.gradle.internal.impldep.com.google.common.base.StandardSystemProperty;
+
+import java.io.File;
+
+/** Creates a new folder for goomph-pde-bootstrap. */
+public class PdeBootstrapInstallationCreate {
+	/** The release to install. */
+	static final EclipseRelease RELEASE = EclipseRelease.official("4.6.3");
+	/** The place to install the release to. */
+	static final File INSTALL_TO = new File(StandardSystemProperty.USER_HOME.value() + "/Desktop/bootstrap");
+
+	public static void main(String[] args) throws Exception {
+		FileMisc.cleanDir(INSTALL_TO);
+		PdeInstallation installation = new PdeInstallation(RELEASE);
+		P2Model model = installation.p2model();
+		model.addMetadataRepo(INSTALL_TO);
+		model.addArtifactRepo(INSTALL_TO);
+		P2Model.DirectorApp app = model.directorApp(INSTALL_TO, "goomph-pde-bootstrap-" + RELEASE.version());
+		app.roaming();
+		app.runUsingBootstrapper();
+	}
+}


### PR DESCRIPTION
A PDE bootstrap installation behind pdeBootstrapUrl can be provided. 
This feature is a benefit for users behind a restrictive proxy.
It behaves identically to p2BootstrapUrl feature.

A PdeInstallationCreate was provided to create a custom PDE bootstrap installation.

The override path must be the rootpath to <rootpath>\VERSION\<goomph-pde-bootstrap.zip|goomph-pde-bootstrap-<VERSION>.zip>