### PR TITLE
Add support for includeLaunchers in product file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.12.0-SNAPSHOT - TBD ([javadoc](http://diffplug.github.io/goomph/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/gradle/goomph/))
 
+- Added support for `includeLaunchers` property from product files [(#58)](https://github.com/diffplug/goomph/pull/58)
+
 ### Version 3.11.1 - February 22nd 2018 ([javadoc](http://diffplug.github.io/goomph/javadoc/3.11.1/), [jcenter](https://bintray.com/diffplug/opensource/goomph/3.11.1/view))
 
 - Bump OSGi version to fix `NoClassDefFoundError: org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap` [(#57)](https://github.com/diffplug/goomph/pull/57)

--- a/src/main/java/com/diffplug/gradle/pde/PdeProductBuildConfig.java
+++ b/src/main/java/com/diffplug/gradle/pde/PdeProductBuildConfig.java
@@ -90,7 +90,7 @@ public class PdeProductBuildConfig {
 		// now create the sanitized product file
 		File productFile = productPluginDir.toPath().resolve(productFileWithinPlugin).toFile();
 		productFileLines = ProductFileUtil.readLines(productFile);
-		ProductFileUtil.extractProperties(productFileLines).forEach((key, value) -> props.setProp(key.toString(), value.toString()));
+		ProductFileUtil.extractProperties(productFileLines).forEach(props::setProp);
 
 		File tempProductFile = tempProductDir.toPath().resolve(productFileWithinPlugin).toFile();
 		transformProductFile(tempProductFile, catalog, version);

--- a/src/main/java/com/diffplug/gradle/pde/PdeProductBuildConfig.java
+++ b/src/main/java/com/diffplug/gradle/pde/PdeProductBuildConfig.java
@@ -30,7 +30,6 @@ import org.gradle.api.Project;
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.common.collect.ImmutableList;
 import com.diffplug.common.swt.os.SwtPlatform;
-import com.diffplug.gradle.FileMisc;
 import com.diffplug.gradle.Lazyable;
 
 /** Models the "product" part of {@link PdeBuildTask}. */

--- a/src/main/java/com/diffplug/gradle/pde/ProductFileUtil.java
+++ b/src/main/java/com/diffplug/gradle/pde/ProductFileUtil.java
@@ -24,10 +24,10 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.diffplug.gradle.FileMisc;
 import org.osgi.framework.Version;
 
 import com.diffplug.common.base.StringPrinter;
+import com.diffplug.gradle.FileMisc;
 
 public class ProductFileUtil {
 	private static final String PLUGIN_PREFIX = "<plugin id=\"";
@@ -100,7 +100,7 @@ public class ProductFileUtil {
 		Properties props = new Properties();
 		for (String line : lines) {
 			Matcher includeLauncherMatcher = INCLUDE_LAUNCHER_REGEX.matcher(line);
-			if(includeLauncherMatcher.matches()) {
+			if (includeLauncherMatcher.matches()) {
 				props.put("includeLaunchers", includeLauncherMatcher.group(1));
 			}
 		}

--- a/src/main/java/com/diffplug/gradle/pde/ProductFileUtil.java
+++ b/src/main/java/com/diffplug/gradle/pde/ProductFileUtil.java
@@ -15,10 +15,16 @@
  */
 package com.diffplug.gradle.pde;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.diffplug.gradle.FileMisc;
 import org.osgi.framework.Version;
 
 import com.diffplug.common.base.StringPrinter;
@@ -33,6 +39,7 @@ public class ProductFileUtil {
 	private static final Pattern PLUGIN_REGEX = Pattern.compile(GROUP + PLUGIN_PREFIX + NO_QUOTE_GROUP + PLUGIN_MIDDLE + GROUP + PLUGIN_SUFFIX);
 
 	private static final Pattern PRODUCT_VERSION_REGEX = Pattern.compile("<product (?:.*) version=\"([^\"]*)\"(?:.*)>");
+	private static final Pattern INCLUDE_LAUNCHER_REGEX = Pattern.compile("<product (?:.*) includeLaunchers=\"([^\"]*)\"(?:.*)>");
 	private static final String VERSION_EQ = "version=";
 
 	static void transformProductFile(StringPrinter printer, String line, PluginCatalog catalog, String version) {
@@ -87,5 +94,21 @@ public class ProductFileUtil {
 		} else {
 			return Optional.empty();
 		}
+	}
+
+	static Properties extractProperties(String[] lines) {
+		Properties props = new Properties();
+		for (String line : lines) {
+			Matcher includeLauncherMatcher = INCLUDE_LAUNCHER_REGEX.matcher(line);
+			if(includeLauncherMatcher.matches()) {
+				props.put("includeLaunchers", includeLauncherMatcher.group(1));
+			}
+		}
+		return props;
+	}
+
+	static String[] readLines(File productFile) throws IOException {
+		String inputStr = new String(Files.readAllBytes(productFile.toPath()), StandardCharsets.UTF_8);
+		return FileMisc.toUnixNewline(inputStr).split("\n");
 	}
 }

--- a/src/main/java/com/diffplug/gradle/pde/ProductFileUtil.java
+++ b/src/main/java/com/diffplug/gradle/pde/ProductFileUtil.java
@@ -19,8 +19,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -96,8 +97,8 @@ public class ProductFileUtil {
 		}
 	}
 
-	static Properties extractProperties(String[] lines) {
-		Properties props = new Properties();
+	static Map<String, String> extractProperties(String[] lines) {
+		Map<String, String> props = new LinkedHashMap<>();
 		for (String line : lines) {
 			Matcher includeLauncherMatcher = INCLUDE_LAUNCHER_REGEX.matcher(line);
 			if (includeLauncherMatcher.matches()) {

--- a/src/test/java/com/diffplug/gradle/pde/ProductFileUtilTest.java
+++ b/src/test/java/com/diffplug/gradle/pde/ProductFileUtilTest.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright 2016 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.diffplug.gradle.pde;
 
-import org.gradle.api.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Properties;
 
 public class ProductFileUtilTest {
 

--- a/src/test/java/com/diffplug/gradle/pde/ProductFileUtilTest.java
+++ b/src/test/java/com/diffplug/gradle/pde/ProductFileUtilTest.java
@@ -25,7 +25,7 @@ public class ProductFileUtilTest {
 
 		String launcherTrue = "<product uid=\"com.diffplug.gradle.pde.product\" id=\"com.diffplug.gradle.pde.productId\" application=\"org.eclipse.ui.ide.workbench\" version=\"1.0.0\" useFeatures=\"false\" includeLaunchers=\"true\">";
 
-		String property = ProductFileUtil.extractProperties(new String[]{launcherTrue}).getProperty("includeLaunchers");
+		String property = ProductFileUtil.extractProperties(new String[]{launcherTrue}).get("includeLaunchers");
 
 		Assert.assertEquals("true", property);
 	}
@@ -35,7 +35,7 @@ public class ProductFileUtilTest {
 
 		String launcherFalse = "<product uid=\"com.diffplug.gradle.pde.product\" id=\"com.diffplug.gradle.pde.productId\" application=\"org.eclipse.ui.ide.workbench\" version=\"1.0.0\" useFeatures=\"false\" includeLaunchers=\"false\">";
 
-		String property = ProductFileUtil.extractProperties(new String[]{launcherFalse}).getProperty("includeLaunchers");
+		String property = ProductFileUtil.extractProperties(new String[]{launcherFalse}).get("includeLaunchers");
 
 		Assert.assertEquals("false", property);
 	}
@@ -45,7 +45,7 @@ public class ProductFileUtilTest {
 
 		String launcherEmpty = "<product uid=\"com.diffplug.gradle.pde.product\" id=\"com.diffplug.gradle.pde.productId\" application=\"org.eclipse.ui.ide.workbench\" version=\"1.0.0\" useFeatures=\"false\" >";
 
-		String property = ProductFileUtil.extractProperties(new String[]{launcherEmpty}).getProperty("includeLaunchers");
+		String property = ProductFileUtil.extractProperties(new String[]{launcherEmpty}).get("includeLaunchers");
 
 		Assert.assertNull(property);
 	}

--- a/src/test/java/com/diffplug/gradle/pde/ProductFileUtilTest.java
+++ b/src/test/java/com/diffplug/gradle/pde/ProductFileUtilTest.java
@@ -1,0 +1,41 @@
+package com.diffplug.gradle.pde;
+
+import org.gradle.api.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Properties;
+
+public class ProductFileUtilTest {
+
+	@Test
+	public void testIncludeLauncherTrue() {
+
+		String launcherTrue = "<product uid=\"com.diffplug.gradle.pde.product\" id=\"com.diffplug.gradle.pde.productId\" application=\"org.eclipse.ui.ide.workbench\" version=\"1.0.0\" useFeatures=\"false\" includeLaunchers=\"true\">";
+
+		String property = ProductFileUtil.extractProperties(new String[]{launcherTrue}).getProperty("includeLaunchers");
+
+		Assert.assertEquals("true", property);
+	}
+
+	@Test
+	public void testIncludeLauncherFalse() {
+
+		String launcherFalse = "<product uid=\"com.diffplug.gradle.pde.product\" id=\"com.diffplug.gradle.pde.productId\" application=\"org.eclipse.ui.ide.workbench\" version=\"1.0.0\" useFeatures=\"false\" includeLaunchers=\"false\">";
+
+		String property = ProductFileUtil.extractProperties(new String[]{launcherFalse}).getProperty("includeLaunchers");
+
+		Assert.assertEquals("false", property);
+	}
+
+	@Test
+	public void testIncludeLauncherEmpty() {
+
+		String launcherEmpty = "<product uid=\"com.diffplug.gradle.pde.product\" id=\"com.diffplug.gradle.pde.productId\" application=\"org.eclipse.ui.ide.workbench\" version=\"1.0.0\" useFeatures=\"false\" >";
+
+		String property = ProductFileUtil.extractProperties(new String[]{launcherEmpty}).getProperty("includeLaunchers");
+
+		Assert.assertNull(property);
+	}
+}


### PR DESCRIPTION
The following line is copied from a example product file:
`<product uid="com.foo.plugin.product" id="com.foo.plugin.product" application="org.eclipse.ui.ide.workbench" version="1.0.0" useFeatures="false" includeLaunchers="false">`

`PdeBuildTask` will now extract this property and adds it to `PdeBuildProperties`.
A launcher is now excluded or included in the PDE export.

@nedtwigg would you mind doing a code review?