### PR TITLE
Fixed unit tests on osx

### DIFF
--- a/src/test/java/com/diffplug/gradle/pde/PdeInstallationPropertiesTest.java
+++ b/src/test/java/com/diffplug/gradle/pde/PdeInstallationPropertiesTest.java
@@ -32,7 +32,7 @@ public class PdeInstallationPropertiesTest {
 		Project project = ProjectBuilder.builder().build();
 		ExtraPropertiesExtension props = project.getExtensions().getExtraProperties();
 
-		props.set("GOOMPH_PDE_VER", "1.0.0");
+		props.set("GOOMPH_PDE_VER", "4.5.0");
 		props.set("GOOMPH_PDE_UPDATE_SITE", expectedSite);
 		props.set("GOOMPH_PDE_ID", expectedId);
 
@@ -50,7 +50,7 @@ public class PdeInstallationPropertiesTest {
 		Project project = ProjectBuilder.builder().build();
 		ExtraPropertiesExtension props = project.getExtensions().getExtraProperties();
 
-		props.set("GOOMPH_PDE_VER", "1.0.0");
+		props.set("GOOMPH_PDE_VER", "4.5.0");
 		props.set("GOOMPH_PDE_UDPATE_SITE", expectedSite);
 		props.set("GOOMPH_PDE_ID", expectedId);
 


### PR DESCRIPTION
Since only eclipse versions > 4.5 are supported on osx, the version in the unit tests should be set to 4.5.0

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/goomph/blob/master/CHANGES.md) that includes:

- [ ] a summary of the change
- [ ] a link to the newly created PR

This makes it easier for the maintainers to quickly release your changes.
