### PR TITLE
This fixes #65 EquinoxLaunch cannot handle EXIT_ASYNC_RESULT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Goomph releases
 
+- EquinoxLaunch handles applications with async exist code (EXIT_ASYNC_RESULT) [(#66)](https://github.com/diffplug/goomph/pull/66)
+
 ### Version 3.14.0-SNAPSHOT - TBD ([javadoc](http://diffplug.github.io/goomph/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/gradle/goomph/))
 
 ### Version 3.13.0 - March 20th 2018 ([javadoc](http://diffplug.github.io/goomph/javadoc/3.13.0/), [jcenter](https://bintray.com/diffplug/opensource/goomph/3.13.0/view))

--- a/src/main/java/com/diffplug/gradle/eclipserunner/EquinoxLauncher.java
+++ b/src/main/java/com/diffplug/gradle/eclipserunner/EquinoxLauncher.java
@@ -190,17 +190,17 @@ public class EquinoxLauncher {
 		/** Runs an eclipse application, as specified by the `-application` argument. */
 		private void run() throws Exception {
 			EclipseStarter.run(null);
-			
+
 			// request now, after shutdown the bundleContext cannot be queried
 			BundleContext bundleContext = EclipseStarter.getSystemBundleContext();
-			
+
 			// wait for the termination of the application
 			// this needed if the application does not do all its work in the IApplication#start
 			// and sets the exit code asynchronously
 			EclipseStarter.shutdown();
 
 			String result = bundleContext.getProperty(EclipseStarter.PROP_EXITCODE);
-			
+
 			Preconditions.checkState("0".equals(result), "Unexpected return=0, was: %s", result);
 		}
 

--- a/src/main/java/com/diffplug/gradle/eclipserunner/EquinoxLauncher.java
+++ b/src/main/java/com/diffplug/gradle/eclipserunner/EquinoxLauncher.java
@@ -189,8 +189,19 @@ public class EquinoxLauncher {
 
 		/** Runs an eclipse application, as specified by the `-application` argument. */
 		private void run() throws Exception {
-			Object result = EclipseStarter.run(null);
-			Preconditions.checkState(Integer.valueOf(0).equals(result), "Unexpected return=0, was: %s", result);
+			EclipseStarter.run(null);
+			
+			// request now, after shutdown the bundleContext cannot be queried
+			BundleContext bundleContext = EclipseStarter.getSystemBundleContext();
+			
+			// wait for the termination of the application
+			// this needed if the application does not do all its work in the IApplication#start
+			// and sets the exit code asynchronously
+			EclipseStarter.shutdown();
+
+			String result = bundleContext.getProperty(EclipseStarter.PROP_EXITCODE);
+			
+			Preconditions.checkState("0".equals(result), "Unexpected return=0, was: %s", result);
 		}
 
 		/** Shutsdown the eclipse instance. */


### PR DESCRIPTION
Wait for the termination of the application and query then the exit code over the properties.
This is needed, if the IApplication#start() returns IApplicationContext.EXIT_ASYNC_RESULT.

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/goomph/blob/master/CHANGES.md) that includes:

- [ ] a summary of the change
- [ ] a link to the newly created PR

This makes it easier for the maintainers to quickly release your changes.
