### PR TITLE
Add BndManifest support for every Jar task

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Version 3.17.0-SNAPSHOT - TBD ([javadoc](http://diffplug.github.io/goomph/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/gradle/goomph/))
 
 - Generated manifest is now put into the output resources directory, to make sure that it's available at runtime for development.
+- Add BndManifest support for every Jar task [(#79)](https://github.com/diffplug/goomph/pull/79)
 
 ### Version 3.16.0 - August 1st 2018 ([javadoc](http://diffplug.github.io/goomph/javadoc/3.16.0/), [jcenter](https://bintray.com/diffplug/opensource/goomph/3.16.0/view))
 

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestExtension.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestExtension.java
@@ -15,8 +15,18 @@
  */
 package com.diffplug.gradle.osgi;
 
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.util.GUtil;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
 /** Determines where the manifest is written out by {@link BndManifestPlugin}. */
 public class BndManifestExtension {
+	public String copyFromTask = JavaPlugin.JAR_TASK_NAME;
+
+	public void copyFromTask(String copyFromTask) { this.copyFromTask = copyFromTask; }
+
 	public Object copyTo = null;
 
 	public void copyTo(Object copyTo) {
@@ -27,6 +37,25 @@ public class BndManifestExtension {
 
 	public void mergeWithExisting(boolean mergeWithExisting) {
 		this.mergeWithExisting = mergeWithExisting;
+	}
+
+	public Set<Object> includeTasks = new HashSet<>(Collections.singletonList(JavaPlugin.JAR_TASK_NAME));
+
+	public void includeTask(Object task) {
+		includeTasks.add(task);
+	}
+
+	public void includeTasks(Object... tasks) {
+		Collections.addAll(includeTasks, tasks);
+	}
+
+	public void setIncludeTasks(Iterable<?> includeTasks) {
+		this.includeTasks.clear();
+		GUtil.addToCollection(this.includeTasks, includeTasks);
+	}
+
+	private String print(){
+		return this.includeTasks.stream().map(o -> (String)o).collect(Collectors.joining(", "));
 	}
 
 	static final String NAME = "osgiBndManifest";

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestExtension.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestExtension.java
@@ -15,17 +15,19 @@
  */
 package com.diffplug.gradle.osgi;
 
-import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.util.GUtil;
-
 import java.util.*;
 import java.util.stream.Collectors;
+
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.util.GUtil;
 
 /** Determines where the manifest is written out by {@link BndManifestPlugin}. */
 public class BndManifestExtension {
 	public String copyFromTask = JavaPlugin.JAR_TASK_NAME;
 
-	public void copyFromTask(String copyFromTask) { this.copyFromTask = copyFromTask; }
+	public void copyFromTask(String copyFromTask) {
+		this.copyFromTask = copyFromTask;
+	}
 
 	public Object copyTo = null;
 
@@ -54,8 +56,8 @@ public class BndManifestExtension {
 		GUtil.addToCollection(this.includeTasks, includeTasks);
 	}
 
-	private String print(){
-		return this.includeTasks.stream().map(o -> (String)o).collect(Collectors.joining(", "));
+	private String print() {
+		return this.includeTasks.stream().map(o -> (String) o).collect(Collectors.joining(", "));
 	}
 
 	static final String NAME = "osgiBndManifest";

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestExtension.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestExtension.java
@@ -16,7 +16,6 @@
 package com.diffplug.gradle.osgi;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.util.GUtil;
@@ -54,10 +53,6 @@ public class BndManifestExtension {
 	public void setIncludeTasks(Iterable<?> includeTasks) {
 		this.includeTasks.clear();
 		GUtil.addToCollection(this.includeTasks, includeTasks);
-	}
-
-	private String print() {
-		return this.includeTasks.stream().map(o -> (String) o).collect(Collectors.joining(", "));
 	}
 
 	static final String NAME = "osgiBndManifest";

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -101,6 +101,9 @@ public class BndManifestPlugin extends ProjectPlugin {
 
 			final Jar copyFromTask = (extension.copyFromTask == null) ? null : getAsJar(proj, extension.copyFromTask);
 
+			Preconditions.checkArgument(extension.copyFromTask == null || extension.includeTasks.contains(extension.copyFromTask),
+                    "copyFromTask must reside within includeTask");
+
 			extension.includeTasks.forEach(name -> {
 
 				Jar jarTask = getAsJar(proj, (String) name);

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -96,7 +96,7 @@ public class BndManifestPlugin extends ProjectPlugin {
 		ProjectPlugin.getPlugin(proj, JavaPlugin.class);
 		BndManifestExtension extension = proj.getExtensions().create(BndManifestExtension.NAME, BndManifestExtension.class);
 
-		proj.getGradle().getTaskGraph().whenReady( taskGraph ->  {
+		proj.getGradle().getTaskGraph().whenReady(taskGraph -> {
 
 			// use all tasks which extends Jar
 			TaskCollection<Jar> jarTasks = proj.getTasks().withType(Jar.class);

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -184,7 +184,7 @@ public class BndManifestPlugin extends ProjectPlugin {
 			JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
 			SourceSetOutput main = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput();
 			// delete empty folders so that bnd doesn't make Export-Package entries for them
-			Set<String> includeresource = new HashSet<>();
+			Set<String> includeresource = new LinkedHashSet<>();
 			deleteEmptyFoldersIfExists(main.getResourcesDir());
 			includeresource.add(fix(main.getResourcesDir()));
 			for (File file : main.getClassesDirs()) {

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -25,7 +25,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Function;
 
-import com.diffplug.common.base.*;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.java.archives.Attributes;
@@ -38,6 +37,7 @@ import org.gradle.api.tasks.bundling.Jar;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
 
+import com.diffplug.common.base.*;
 import com.diffplug.common.collect.ImmutableMap;
 import com.diffplug.gradle.FileMisc;
 import com.diffplug.gradle.ProjectPlugin;
@@ -88,12 +88,12 @@ import com.diffplug.gradle.ZipMisc;
  * features and tighter integrations with IDEs and gradle's resources pipeline.
  */
 public class BndManifestPlugin extends ProjectPlugin {
-    @Override
-    protected void applyOnce(Project proj) {
-        ProjectPlugin.getPlugin(proj, JavaPlugin.class);
-        BndManifestExtension extension = proj.getExtensions().create(BndManifestExtension.NAME, BndManifestExtension.class);
+	@Override
+	protected void applyOnce(Project proj) {
+		ProjectPlugin.getPlugin(proj, JavaPlugin.class);
+		BndManifestExtension extension = proj.getExtensions().create(BndManifestExtension.NAME, BndManifestExtension.class);
 
-        proj.afterEvaluate(project -> {
+		proj.afterEvaluate(project -> {
 
 			// copyFromTask must be configured if copyTo is used
 			Preconditions.checkArgument(extension.copyTo == null || extension.copyFromTask != null,
@@ -102,7 +102,7 @@ public class BndManifestPlugin extends ProjectPlugin {
 			final Jar copyFromTask = (extension.copyFromTask == null) ? null : getAsJar(proj, extension.copyFromTask);
 
 			Preconditions.checkArgument(extension.copyFromTask == null || extension.includeTasks.contains(extension.copyFromTask),
-                    "copyFromTask must reside within includeTask");
+					"copyFromTask must reside within includeTask");
 
 			extension.includeTasks.forEach(name -> {
 
@@ -135,12 +135,12 @@ public class BndManifestPlugin extends ProjectPlugin {
 				});
 			});
 
-            // find the file that the user would like us to copy to (if any)
-            if (extension.copyTo != null && copyFromTask != null) {
-                copyFromTask.getOutputs().file(extension.copyTo);
-            }
-        });
-    }
+			// find the file that the user would like us to copy to (if any)
+			if (extension.copyTo != null && copyFromTask != null) {
+				copyFromTask.getOutputs().file(extension.copyTo);
+			}
+		});
+	}
 
 	private static Path outputManifest(Jar jarTask) {
 		JavaPluginConvention javaConvention = jarTask.getProject().getConvention().getPlugin(JavaPluginConvention.class);
@@ -228,7 +228,7 @@ public class BndManifestPlugin extends ProjectPlugin {
 
 	private static Jar getAsJar(Project project, String taskName) {
 		Task task = project.getTasks().getByName(taskName);
-		Preconditions.checkArgument(task instanceof Jar,  "Task " + taskName + " must be a Jar derived task for generating BndManifest");
-		return (Jar)task;
+		Preconditions.checkArgument(task instanceof Jar, "Task " + taskName + " must be a Jar derived task for generating BndManifest");
+		return (Jar) task;
 	}
 }

--- a/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
+++ b/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
@@ -105,8 +105,8 @@ public class BndManifestPluginTest extends GradleIntegrationTest {
 				"	classifier 'custom'",
 				"}",
 				"osgiBndManifest { ",
-					"mergeWithExisting true",
-					"includeTask 'customJar'",
+				"mergeWithExisting true",
+				"includeTask 'customJar'",
 				"}");
 
 		testCase(buildScript, expectedMerge, "customJar");

--- a/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
+++ b/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
@@ -74,7 +74,47 @@ public class BndManifestPluginTest extends GradleIntegrationTest {
 		testCase("osgiBndManifest { mergeWithExisting true }", expectedMerge);
 	}
 
+    @Test
+    public void assertCustomJarTasks() throws IOException {
+        write("src/main/resources/META-INF/MANIFEST.MF",
+                "Manifest-Version: 1.0",
+                "Bundle-ManifestVersion: 2",
+                "Bundle-Name: Mock",
+                "Bundle-SymbolicName: org.eclipse.e4.demo.e4photo.flickr.mock; singleton:=true",
+                "Bundle-Version: 1.0.0.qualifier",
+                "Bundle-ActivationPolicy: lazy",
+                "Require-Bundle: org.eclipse.core.runtime");
+        String expectedMerge = StringPrinter.buildStringFromLines(
+                "Manifest-Version: 1.0",
+                "Bundle-ActivationPolicy: lazy",
+                "Bundle-ManifestVersion: 2",
+                "Bundle-SymbolicName: test",
+                "Bundle-Version: 0.0.0.ERRORSETVERSION",
+                "Export-Package: test;uses:=\"com.diffplug.common.base\";version=\"0.0.0\"",
+                "Import-Package: com.diffplug.common.base;version=\"[3.4,4)\"",
+                "Require-Bundle: org.eclipse.core.runtime",
+                "Require-Capability: osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\"");
+        String buildScript = StringPrinter.buildStringFromLines(
+				"task customJar(type: Jar) {",
+				"  with jar",
+				"  manifest.attributes(",
+				"    '-exportcontents': 'test.*',",
+				"    '-removeheaders': 'Bnd-LastModified,Bundle-Name,Created-By,Tool,Private-Package',",
+				"    'Bundle-SymbolicName': 'test'",
+				"  )",
+				"	classifier 'custom'",
+				"}",
+				"osgiBndManifest { mergeWithExisting true }"
+		);
+
+        testCase(buildScript, expectedMerge, "customJar");
+    }
+
 	private void testCase(String buildscriptAddendum, String expectedManifest) throws IOException {
+		testCase(buildscriptAddendum, expectedManifest, "jar");
+	}
+
+	private void testCase(String buildscriptAddendum, String expectedManifest, String task) throws IOException {
 		write("build.gradle",
 				"plugins {",
 				"    id 'java'",
@@ -98,7 +138,7 @@ public class BndManifestPluginTest extends GradleIntegrationTest {
 				"		return new StringPrinter(str -> {});",
 				"	}",
 				"}");
-		gradleRunner().withArguments("jar", "--stacktrace").build();
+		gradleRunner().withArguments(task, "--stacktrace", "-i").withDebug(true).build();
 
 		// make sure the jar contains the proper manifest
 		File libsDir = file("build/libs");

--- a/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
+++ b/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
@@ -74,27 +74,27 @@ public class BndManifestPluginTest extends GradleIntegrationTest {
 		testCase("osgiBndManifest { mergeWithExisting true }", expectedMerge);
 	}
 
-    @Test
-    public void assertCustomJarTasks() throws IOException {
-        write("src/main/resources/META-INF/MANIFEST.MF",
-                "Manifest-Version: 1.0",
-                "Bundle-ManifestVersion: 2",
-                "Bundle-Name: Mock",
-                "Bundle-SymbolicName: org.eclipse.e4.demo.e4photo.flickr.mock; singleton:=true",
-                "Bundle-Version: 1.0.0.qualifier",
-                "Bundle-ActivationPolicy: lazy",
-                "Require-Bundle: org.eclipse.core.runtime");
-        String expectedMerge = StringPrinter.buildStringFromLines(
-                "Manifest-Version: 1.0",
-                "Bundle-ActivationPolicy: lazy",
-                "Bundle-ManifestVersion: 2",
-                "Bundle-SymbolicName: test",
-                "Bundle-Version: 0.0.0.ERRORSETVERSION",
-                "Export-Package: test;uses:=\"com.diffplug.common.base\";version=\"0.0.0\"",
-                "Import-Package: com.diffplug.common.base;version=\"[3.4,4)\"",
-                "Require-Bundle: org.eclipse.core.runtime",
-                "Require-Capability: osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\"");
-        String buildScript = StringPrinter.buildStringFromLines(
+	@Test
+	public void assertCustomJarTasks() throws IOException {
+		write("src/main/resources/META-INF/MANIFEST.MF",
+				"Manifest-Version: 1.0",
+				"Bundle-ManifestVersion: 2",
+				"Bundle-Name: Mock",
+				"Bundle-SymbolicName: org.eclipse.e4.demo.e4photo.flickr.mock; singleton:=true",
+				"Bundle-Version: 1.0.0.qualifier",
+				"Bundle-ActivationPolicy: lazy",
+				"Require-Bundle: org.eclipse.core.runtime");
+		String expectedMerge = StringPrinter.buildStringFromLines(
+				"Manifest-Version: 1.0",
+				"Bundle-ActivationPolicy: lazy",
+				"Bundle-ManifestVersion: 2",
+				"Bundle-SymbolicName: test",
+				"Bundle-Version: 0.0.0.ERRORSETVERSION",
+				"Export-Package: test;uses:=\"com.diffplug.common.base\";version=\"0.0.0\"",
+				"Import-Package: com.diffplug.common.base;version=\"[3.4,4)\"",
+				"Require-Bundle: org.eclipse.core.runtime",
+				"Require-Capability: osgi.ee;filter:=\"(&(osgi.ee=JavaSE)(version=1.8))\"");
+		String buildScript = StringPrinter.buildStringFromLines(
 				"task customJar(type: Jar) {",
 				"  with jar",
 				"  manifest.attributes(",
@@ -104,11 +104,10 @@ public class BndManifestPluginTest extends GradleIntegrationTest {
 				"  )",
 				"	classifier 'custom'",
 				"}",
-				"osgiBndManifest { mergeWithExisting true }"
-		);
+				"osgiBndManifest { mergeWithExisting true }");
 
-        testCase(buildScript, expectedMerge, "customJar");
-    }
+		testCase(buildScript, expectedMerge, "customJar");
+	}
 
 	private void testCase(String buildscriptAddendum, String expectedManifest) throws IOException {
 		testCase(buildscriptAddendum, expectedManifest, "jar");

--- a/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
+++ b/src/test/java/com/diffplug/gradle/osgi/BndManifestPluginTest.java
@@ -104,7 +104,10 @@ public class BndManifestPluginTest extends GradleIntegrationTest {
 				"  )",
 				"	classifier 'custom'",
 				"}",
-				"osgiBndManifest { mergeWithExisting true }");
+				"osgiBndManifest { ",
+					"mergeWithExisting true",
+					"includeTask 'customJar'",
+				"}");
 
 		testCase(buildScript, expectedMerge, "customJar");
 	}


### PR DESCRIPTION
Currently the BndManifestPlugin targets only the default jar task.

This feature applies the plugin on every task which is extending `Jar`.

