### PR TITLE
Rebuild javadoc when package lists are updated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Version 3.18.2-SNAPSHOT - TBD ([javadoc](https://diffplug.github.io/goomph/javadoc/snapshot/), [snapshot](https://oss.sonatype.org/content/repositories/snapshots/com/diffplug/gradle/goomph/))
 
+- Added package lists as inputs to the task `javadoc` [#110](https://github.com/diffplug/goomph/pull/110)
+
 ### Version 3.18.1 - September 20th 2019 ([javadoc](https://diffplug.github.io/goomph/javadoc/3.18.1/), [jcenter](https://bintray.com/diffplug/opensource/goomph/3.18.1/view))
 
 - Added eclipse `4.13.0` aka `2019-09`.

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ def javadocInfo = '<h2>' + makeLink("https://github.com/${org}/${name}", "${grou
 def verSnapshot = { it.endsWith('-SNAPSHOT') ? 'snapshot' : it }
 
 javadoc {
+    inputs.dir "$project.projectDir/gradle/javadoc"
 	// Where it's possible to name parameters and methods clearly enough
 	// that javadoc is not necessary, why make the code bigger?
 	//


### PR DESCRIPTION
Hello

This commit enhances the build script of the project.
Specifically, it adds the input directory of the task `javadoc` so that this task can be incrementally built
whenever there are updates to those package lists.
