### PR TITLE
Fix up markdown formatting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Goomph releases
 
 ## [Unreleased]
+- Fix markdown formatting for the `AsMavenPlugin` javadocs ([https://github.com/diffplug/goomph/pull/118])
 
 ## [3.21.0] - 2020-01-26
 ### Added

--- a/src/main/java/com/diffplug/gradle/p2/AsMavenPlugin.java
+++ b/src/main/java/com/diffplug/gradle/p2/AsMavenPlugin.java
@@ -134,13 +134,13 @@ import org.gradle.api.Project;
  * 
  * You can see all the available slicing options [here](https://wiki.eclipse.org/Equinox/p2/Ant_Tasks#SlicingOptions).
  *
- *  ## Append option
+ * ## Append option
  *
- *  You can control whether iu's should be appended to destination repository
- *  true: already downloaded iu's are preserved, new iu's are downloaded into the existing repo
- *  false: Default value for goomph, repository will be completely cleared before download new iu's
+ * You can control whether iu's should be appended to destination repository
+ * true: already downloaded iu's are preserved, new iu's are downloaded into the existing repo
+ * false: Default value for goomph, repository will be completely cleared before download new iu's
  *
- *   * ```groovy
+ * ```groovy
  * p2AsMaven {
  *   group 'eclipse-deps', {
  *     ...
@@ -149,7 +149,7 @@ import org.gradle.api.Project;
  * }
  * ```
  *
- * More info [here]{https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_repositorytasks.htm}.
+ * More info [here](https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_repositorytasks.htm).
  *
  * ## Acknowledgements and comparisons to other options
  * 


### PR DESCRIPTION
Hi there 👋  Been following the instructions in an attempt to convert an Eclipse plugin of mine over to fully using Gradle, and spotted the Javadocs for the `AsMavenPlugin` get a bit funny towards from the "Append option" section onwards:

![Screen Shot 2020-02-01 at 11 05 40 PM](https://user-images.githubusercontent.com/1686920/73590518-42dd9080-4548-11ea-93e0-c3e46e881f3b.png)

This PR clears up the formatting issue so that the javadocs can render a bit more nicely.
