### PR TITLE
Classloading issue with Gradle 6.7+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Goomph releases
 
 ## [Unreleased]
-
+### Fixed
 * Added support for using Goomph (pde bootstrap) with Gradle `6.7` and newer ([#147](https://github.com/diffplug/goomph/pull/147))
 
 ## [3.29.1] - 2021-04-09

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Added support for using Goomph (pde bootstrap) with Gradle `6.7` and newer ([#147](https://github.com/diffplug/goomph/pull/147))
+
 ## [3.29.1] - 2021-04-09
 ### Fixed
 * `p2asmaven` works again, but requires JRE 8. ([#145](https://github.com/diffplug/goomph/pull/145))

--- a/src/main/java/com/diffplug/gradle/JavaExecableImp.java
+++ b/src/main/java/com/diffplug/gradle/JavaExecableImp.java
@@ -86,6 +86,8 @@ class JavaExecableImp {
 		addPeerClasses.accept(JavaExecable.class);
 		// add the gradle API
 		addPeerClasses.accept(JavaExec.class);
+		// Needed because of Gradle API classloader hierarchy changes with 2c5adc8 in Gradle 6.7+
+		addPeerClasses.accept(FileCollection.class);
 		return files;
 	}
 }


### PR DESCRIPTION
Fixed failing PDE bootstrap using Goomph in projects with Gradle 6.7 and higher.