### PR TITLE
Update bndlib to version '6.1.0'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Fixed
+- Bumped `bndlib` from `5.3.0` to `6.1.0` which no longer includes copies of the OSGi packages ([#172](https://github.com/diffplug/goomph/pull/172))
 
 ## [3.33.2] - 2021-11-05
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ spotless {
 
 String VER_DURIAN = '1.2.0'
 String VER_DURIAN_SWT = '3.5.0'
-String VER_BNDLIB = '5.3.0'
+String VER_BNDLIB = '6.1.0'
 String OLDEST_SUPPORTED_GRADLE = '5.1'
 String VER_P2_BOOTSTRAP = '4.13.0'
 


### PR DESCRIPTION
According to the feedback from the bnd project in https://github.com/bndtools/bnd/issues/4969#issuecomment-981823726 updating to a newer bndlib version might fix the `org.osgi.service.log` package issue.

Newer version of bndlib no longer include copies of the OSGi packages.