### PR TITLE
Bump up spotless-lib to 2.20.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Fixed
+- Bumped `spotless-lib` from `1.5.1` to `2.21.0` which is used in the [latest spotless gradle plugin](https://github.com/diffplug/spotless/releases/tag/gradle%2F6.1.0).
 
 ## [3.34.0] - 2021-12-16
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Bumped `spotless-lib` from `1.5.1` to `2.21.0` which is used in the [latest spotless gradle plugin](https://github.com/diffplug/spotless/releases/tag/gradle%2F6.1.0) ([#176](https://github.com/diffplug/goomph/pull/176))
+- Bumped `spotless-lib` from `1.5.1` to `2.20.0` which is used in the [spotless gradle plugin v6.0.0](https://github.com/diffplug/spotless/releases/tag/gradle%2F6.0.0) ([#176](https://github.com/diffplug/goomph/pull/176))
 
 ## [3.34.0] - 2021-12-16
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Bumped `spotless-lib` from `1.5.1` to `2.21.0` which is used in the [latest spotless gradle plugin](https://github.com/diffplug/spotless/releases/tag/gradle%2F6.1.0).
+- Bumped `spotless-lib` from `1.5.1` to `2.21.0` which is used in the [latest spotless gradle plugin](https://github.com/diffplug/spotless/releases/tag/gradle%2F6.1.0) ([#176](https://github.com/diffplug/goomph/pull/176))
 
 ## [3.34.0] - 2021-12-16
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation "com.diffplug.durian:durian-io:${VER_DURIAN}"
 	implementation "com.diffplug.durian:durian-swt.os:${VER_DURIAN_SWT}"
 	implementation "commons-io:commons-io:2.6"
-	implementation "com.diffplug.spotless:spotless-lib:2.21.0"
+	implementation "com.diffplug.spotless:spotless-lib:2.20.0"
 	implementation "com.squareup.okhttp3:okhttp:4.3.1"
 	implementation "com.squareup.okio:okio:2.4.3"
 	// OSGi

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation "com.diffplug.durian:durian-io:${VER_DURIAN}"
 	implementation "com.diffplug.durian:durian-swt.os:${VER_DURIAN_SWT}"
 	implementation "commons-io:commons-io:2.6"
-	implementation "com.diffplug.spotless:spotless-lib:1.5.1"
+	implementation "com.diffplug.spotless:spotless-lib:2.21.0"
 	implementation "com.squareup.okhttp3:okhttp:4.3.1"
 	implementation "com.squareup.okio:okio:2.4.3"
 	// OSGi


### PR DESCRIPTION
Hello :wave: thanks for sharing such a nice Gradle plugin!
It helps a lot to [remove dependency on Eclipse in local](https://github.com/spotbugs/spotbugs/pull/1735).

I'm trying to introduce this plugin to a Gradle project depending on the spotless gradle plugin.
But when I run the build, it [failed due to the following error](https://github.com/spotbugs/spotbugs/runs/4647242128?check_suite_focus=true#step:6:87):

> Receiver class com.diffplug.gradle.spotless.GradleProvisioner$DedupingProvisioner does not define or inherit an implementation of the resolved method 'abstract java.util.Set provisionWithDependencies(java.util.Collection)' of interface com.diffplug.spotless.Provisioner.

I found that this plugin depends on old `spotless-lib`, and it brings a conflict into the classpath. So in this PR, I want to suggest upgrading the `spotless-lib` to 2.20.0.

----

Please make sure that your [PR allows edits from maintainers](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).  Sometimes its faster for us to just fix something than it is to describe how to fix it.

![Allow edits from maintainers](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)

After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/goomph/blob/main/CHANGES.md) that includes:

- [x] a summary of the change
- [x] a link to the newly created PR

This makes it easier for the maintainers to quickly release your changes.
