### PR TITLE
Fix javadoc

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,11 @@
 pluginManagement {
 	plugins {
-		id 'com.diffplug.blowdryer'                version '1.1.1'
-		id 'com.diffplug.blowdryerSetup'           version '1.1.1'
+		id 'com.diffplug.blowdryer'                version '1.5.1'
+		id 'com.diffplug.blowdryerSetup'           version '1.5.1'
 		id 'com.diffplug.eclipse.mavencentral'     version '3.28.0'
-		id 'com.diffplug.spotless-changelog'       version '2.2.0'
-		id 'com.diffplug.spotless'                 version '5.13.0'
-		id 'com.gradle.plugin-publish'             version '0.15.0'
+		id 'com.diffplug.spotless-changelog'       version '2.4.0'
+		id 'com.diffplug.spotless'                 version '6.3.0'
+		id 'com.gradle.plugin-publish'             version '0.20.0'
 		id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 		id 'org.jdrupes.mdoclet'                   version '1.0.10'
 	}
@@ -20,7 +20,7 @@ plugins {
 	id 'org.jdrupes.mdoclet'                   apply false
 }
 blowdryerSetup {
-	github 'diffplug/blowdryer-diffplug', 'tag', '5.1.3'
+	github 'diffplug/blowdryer-diffplug', 'tag', '5.2.0'
 	//devLocal '../blowdryer-diffplug'
 }
 rootProject.name = 'goomph'

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -52,7 +52,7 @@ import org.gradle.api.tasks.bundling.Jar;
  *
  * ```groovy
  * apply plugin: 'com.diffplug.osgi.bndmanifest'
- * // Pass headers and bnd directives: https://www.aqute.biz/Bnd/Format
+ * // Pass headers and bnd instructions: https://bnd.bndtools.org/chapters/825-instructions-ref.html
  * jar.manifest.attributes(
  *     '-exportcontents': 'com.diffplug.*',
  *     '-removeheaders': 'Bnd-LastModified,Bundle-Name,Created-By,Tool,Private-Package',

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 DiffPlug
+ * Copyright (C) 2016-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I am not 100% sure but I think the page was moved to https://bnd.bndtools.org/chapters/825-instructions-ref.html and I also think "instructions" is more correct than "directives"