### PR TITLE
Fix No-Such-Field Exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Fixed
+- Attempt to fix `equinoxLaunch` and `oomphIde` on Java 16+ ([#195](https://github.com/diffplug/goomph/pull/195) fixes [#182](https://github.com/diffplug/goomph/issues/182))
 
 ## [3.37.0] - 2022-06-16
 ### Added

--- a/src/main/java/com/diffplug/gradle/JRE.java
+++ b/src/main/java/com/diffplug/gradle/JRE.java
@@ -54,7 +54,14 @@ public class JRE {
 		} else {
 			// Assume AppClassLoader of Java9+
 			Class<? extends ClassLoader> clz = classLoader.getClass();
-			Field ucpFld = clz.getDeclaredField("ucp");
+			Field ucpFld;
+			try {
+				// Java 9 - 15
+				ucpFld = clz.getDeclaredField("ucp");
+			} catch (NoSuchFieldException e) {
+				// Java 16+
+				ucpFld = clz.getSuperclass().getDeclaredField("ucp");
+			}
 			ucpFld.setAccessible(true);
 			Object ucpObj = ucpFld.get(classLoader);
 			Field pathFld = ucpObj.getClass().getDeclaredField("path");

--- a/src/main/java/com/diffplug/gradle/JRE.java
+++ b/src/main/java/com/diffplug/gradle/JRE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 DiffPlug
+ * Copyright (C) 2021-2022 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes issue https://github.com/diffplug/goomph/issues/182.

I haven't been able to test this because the gradle build for pushToMavenLocal() is failing. The failure is caused by javadoc being unable to be built. At the moment, my machine isn't set up for quick change of java environments, so it's hard to track this down. It seems related to JDK 11, which is what I"m using to run the ./gradlew.

Perhaps you can test this at your end. The fix is extremely straightforward.