### PR TITLE
Add support for 4.26 and equo notice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Added
+- Eclipse `4.26.0` aka `2022-12` ([new and noteworthy](https://www.eclipse.org/eclipse/news/4.26/))
 
 ## [3.40.0] - 2022-10-29
 ### Removed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 ### Added
 - Eclipse `4.26.0` aka `2022-12` ([new and noteworthy](https://www.eclipse.org/eclipse/news/4.26/))
+- We recommend users of the following plugins to migrate as follows:
+  - `com.diffplug.eclipse.mavencentral` and `com.diffplug.p2.asmaven` -> [`dev.equo.p2deps`](https://github.com/equodev/equo-ide/tree/main/plugin-gradle#user-plugins)
+  - `com.diffplug.oomph.ide` -> [`dev.equo.ide`](https://github.com/equodev/equo-ide/tree/main/plugin-gradle)
+  - The legacy plugins will continue to be maintained, so you don't *have* to migrate, but the new plugins are strictly better.
 
 ## [3.40.0] - 2022-10-29
 ### Removed

--- a/src/main/java/com/diffplug/gradle/eclipse/EquoMigration.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/EquoMigration.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.gradle.eclipse;
+
+public class EquoMigration {
+	private static boolean silenceEquoIde = false;
+
+	public static void silenceEquoIDE() {
+		silenceEquoIde = true;
+	}
+
+	private static boolean eclipseMavenCentral = false;
+
+	public static void eclipseMavenCentral() {
+		if (silenceEquoIde || eclipseMavenCentral) {
+			return;
+		}
+		eclipseMavenCentral = true;
+		System.out.println("We strongly recommend that you migrate");
+		System.out.println("  from 'com.diffplug.eclipse.mavencentral'");
+		System.out.println("    to 'dev.equo.p2deps'");
+		System.out.println("The new plugin is faster and works seamlessly with both mavencentral");
+		System.out.println("and all p2 repositories (e.g. CDT, WTP, m2e, gradle buildship, etc.)");
+		System.out.println("");
+		System.out.println("For more info: https://github.com/equodev/equo-ide/tree/main/plugin-gradle#user-plugins");
+		System.out.println("");
+		System.out.println("You can silence this warning with");
+		System.out.println("```");
+		System.out.println("eclipseMavenCentral {");
+		System.out.println("  silenceEquoIDE()");
+		System.out.println("  ...");
+		System.out.println("```");
+	}
+
+	private static boolean asMaven = false;
+
+	public static void asMaven() {
+		if (silenceEquoIde || asMaven) {
+			return;
+		}
+		asMaven = true;
+		System.out.println("We strongly recommend that you migrate");
+		System.out.println("  from 'com.diffplug.p2.asmaven'");
+		System.out.println("    to 'dev.equo.p2deps'");
+		System.out.println("The new plugin is far faster and works seamlessly with both mavencentral");
+		System.out.println("and all p2 repositories (e.g. CDT, WTP, m2e, gradle buildship, etc.)");
+		System.out.println("");
+		System.out.println("For more info: https://github.com/equodev/equo-ide/tree/main/plugin-gradle#user-plugins");
+		System.out.println("");
+		System.out.println("You can silence this warning with");
+		System.out.println("```");
+		System.out.println("p2AsMaven {");
+		System.out.println("  silenceEquoIDE()");
+		System.out.println("  ...");
+		System.out.println("```");
+	}
+
+	private static boolean oomph = false;
+
+	public static void oomph() {
+		if (silenceEquoIde || oomph) {
+			return;
+		}
+		oomph = true;
+		System.out.println("We strongly recommend that you migrate");
+		System.out.println("  from 'com.diffplug.oomph.ide'");
+		System.out.println("    to 'dev.equo.ide'");
+		System.out.println("The new plugin is far faster and works seamlessly with both mavencentral");
+		System.out.println("and all p2 repositories (e.g. CDT, WTP, m2e, gradle buildship, etc.)");
+		System.out.println("");
+		System.out.println("For more info: https://github.com/equodev/equo-ide/blob/main/plugin-gradle/README.md");
+		System.out.println("");
+		System.out.println("You can silence this warning with");
+		System.out.println("```");
+		System.out.println("oomphIde {");
+		System.out.println("  silenceEquoIDE()");
+		System.out.println("  ...");
+		System.out.println("```");
+	}
+}

--- a/src/main/java/com/diffplug/gradle/eclipse/MavenCentralExtension.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/MavenCentralExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 DiffPlug
+ * Copyright (C) 2018-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.gradle.eclipse;
-
 
 import com.diffplug.common.base.StringPrinter;
 import com.diffplug.common.swt.os.SwtPlatform;
@@ -39,12 +38,17 @@ public class MavenCentralExtension {
 		this.project = Objects.requireNonNull(project);
 	}
 
+	public void silenceEquoIDE() {
+		EquoMigration.silenceEquoIDE();
+	}
+
 	public void release(String version, Action<ReleaseConfigurer> configurer) throws IOException {
 		release(EclipseRelease.official(version), configurer);
 	}
 
 	public void release(EclipseRelease release, Action<ReleaseConfigurer> configurer) throws IOException {
 		configurer.execute(new ReleaseConfigurer(release));
+		EquoMigration.eclipseMavenCentral();
 	}
 
 	public class ReleaseConfigurer {

--- a/src/main/java/com/diffplug/gradle/oomph/OomphIdeExtension.java
+++ b/src/main/java/com/diffplug/gradle/oomph/OomphIdeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 DiffPlug
+ * Copyright (C) 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package com.diffplug.gradle.oomph;
 
-
 import com.diffplug.common.base.Errors;
 import com.diffplug.common.base.Preconditions;
 import com.diffplug.common.base.StandardSystemProperty;
@@ -29,6 +28,7 @@ import com.diffplug.gradle.GoomphCacheLocations;
 import com.diffplug.gradle.JavaExecable;
 import com.diffplug.gradle.Lazyable;
 import com.diffplug.gradle.StateBuilder;
+import com.diffplug.gradle.eclipse.EquoMigration;
 import com.diffplug.gradle.eclipserunner.EclipseIni;
 import com.diffplug.gradle.eclipserunner.EclipseIniLauncher;
 import com.diffplug.gradle.oomph.thirdparty.ConventionThirdParty;
@@ -103,6 +103,10 @@ public class OomphIdeExtension implements P2Declarative {
 		this.description = this.name;
 		this.perspective = Perspectives.RESOURCES;
 		this.runP2Using = app -> Errors.rethrow().run(() -> app.runUsingBootstrapper(project));
+	}
+
+	public void silenceEquoIDE() {
+		EquoMigration.silenceEquoIDE();
 	}
 
 	/** Returns the underlying project. */

--- a/src/main/java/com/diffplug/gradle/oomph/OomphIdePlugin.java
+++ b/src/main/java/com/diffplug/gradle/oomph/OomphIdePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 DiffPlug
+ * Copyright (C) 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package com.diffplug.gradle.oomph;
 
-
 import com.diffplug.common.base.Errors;
 import com.diffplug.gradle.GoomphCacheLocations;
 import com.diffplug.gradle.LegacyPlugin;
 import com.diffplug.gradle.ProjectPlugin;
+import com.diffplug.gradle.eclipse.EquoMigration;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
@@ -203,6 +203,7 @@ public class OomphIdePlugin extends ProjectPlugin {
 				if (!extension.workspaceExists()) {
 					ide.dependsOn(ideSetupWorkspace);
 				}
+				EquoMigration.oomph();
 			});
 		});
 

--- a/src/main/java/com/diffplug/gradle/p2/AsMavenExtension.java
+++ b/src/main/java/com/diffplug/gradle/p2/AsMavenExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 DiffPlug
+ * Copyright (C) 2015-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package com.diffplug.gradle.p2;
 
-
 import com.diffplug.common.base.Errors;
 import com.diffplug.gradle.FileMisc;
+import com.diffplug.gradle.eclipse.EquoMigration;
 import java.io.File;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -53,7 +53,12 @@ public class AsMavenExtension {
 		}
 	}
 
+	public void silenceEquoIDE() {
+		EquoMigration.silenceEquoIDE();
+	}
+
 	void run() {
+		EquoMigration.asMaven();
 		Set<File> files = new HashSet<>();
 		File p2asmaven = project.file(destination);
 		groups.forEach((group, action) -> {

--- a/src/main/java/com/diffplug/gradle/pde/EclipseRelease.java
+++ b/src/main/java/com/diffplug/gradle/pde/EclipseRelease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 DiffPlug
+ * Copyright (C) 2015-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.gradle.pde;
-
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -128,6 +127,7 @@ public final class EclipseRelease {
 			case "4.23.0": return root + "4.23/R-4.23-202203080310/";
 			case "4.24.0": return root + "4.24/R-4.24-202206070700/";
 			case "4.25.0": return root + "4.25/R-4.25-202208311800/";
+			case "4.26.0": return root + "4.26/R-4.26-202211231800/";
 			// less-specific versions
 			case "3.5": case "3.6": case "3.7": case "3.8":
 			case "4.2": case "4.3": case "4.4": case "4.5":
@@ -136,6 +136,7 @@ public final class EclipseRelease {
 			case "4.14": case "4.15": case "4.16": case "4.17":
 			case "4.18": case "4.19": case "4.20": case "4.21":
 			case "4.22": case "4.23": case "4.24": case "4.25":
+			case "4.26":
 				return root + v + "/";
 			default: return null;
 			}


### PR DESCRIPTION
Adds support for Eclipse 4.26 and also notifies users of the following plugins of the better options over at EquoIDE

- `com.diffplug.eclipse.mavencentral` and `com.diffplug.p2.asmaven` -> [`dev.equo.p2deps`](https://github.com/equodev/equo-ide/tree/main/plugin-gradle#user-plugins)
- `com.diffplug.oomph.ide` -> [`dev.equo.ide`](https://github.com/equodev/equo-ide/tree/main/plugin-gradle)