### PR TITLE
Upgrade JavaPluginConvention to JavaPluginExtension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Fixed
+- Upgrade JavaPluginConvention to JavaPluginExtension [#208](https://github.com/diffplug/goomph/pull/208) fixes [#207](https://github.com/diffplug/goomph/issues/207)
 
 ## [3.42.1] - 2023-06-26
 ### Fixed

--- a/src/main/java/com/diffplug/gradle/eclipse/apt/AptEclipsePlugin.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/AptEclipsePlugin.java
@@ -25,7 +25,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.PropertiesTransformer;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.xml.XmlTransformer;
@@ -62,12 +62,12 @@ public class AptEclipsePlugin implements Plugin<Project> {
         .withType(
             JavaPlugin.class,
             javaPlugin -> {
-              JavaPluginConvention javaConvention =
-                  project.getConvention().getPlugin(JavaPluginConvention.class);
+              JavaPluginExtension javaExtension =
+                  project.getExtensions().getByType(JavaPluginExtension.class);
               SourceSet mainSourceSet =
-                  javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                  javaExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
               SourceSet testSourceSet =
-                  javaConvention.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
+                  javaExtension.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
 
               configureEclipse(project, mainSourceSet, testSourceSet);
             });

--- a/src/main/java/com/diffplug/gradle/eclipse/apt/AptPlugin.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/AptPlugin.java
@@ -31,9 +31,10 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.HasConvention;
 import org.gradle.api.plugins.GroovyBasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.GroovySourceDirectorySet;
 import org.gradle.api.tasks.GroovySourceSet;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -62,9 +63,9 @@ public class AptPlugin implements Plugin<Project> {
         .withType(
             JavaBasePlugin.class,
             javaBasePlugin -> {
-              final JavaPluginConvention javaConvention =
-                  project.getConvention().getPlugin(JavaPluginConvention.class);
-              javaConvention
+              final JavaPluginExtension javaExtension =
+                  project.getExtensions().getByType(JavaPluginExtension.class);
+              javaExtension
                   .getSourceSets()
                   .all(
                       sourceSet -> {
@@ -84,17 +85,15 @@ public class AptPlugin implements Plugin<Project> {
         .withType(
             GroovyBasePlugin.class,
             groovyBasePlugin -> {
-              JavaPluginConvention javaConvention =
-                  project.getConvention().getPlugin(JavaPluginConvention.class);
-              javaConvention
+              JavaPluginExtension javaExtension =
+                  project.getExtensions().getByType(JavaPluginExtension.class);
+              javaExtension
                   .getSourceSets()
                   .all(
                       sourceSet -> {
                         SourceDirectorySet groovy =
-                            ((HasConvention) sourceSet)
-                                .getConvention()
-                                .getPlugin(GroovySourceSet.class)
-                                .getGroovy();
+                            sourceSet.getExtensions()
+                                .getByType(GroovySourceDirectorySet.class);
                         configureCompileTaskForSourceSet(
                             project,
                             sourceSet,

--- a/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
+++ b/src/main/java/com/diffplug/gradle/osgi/BndManifestPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 DiffPlug
+ * Copyright (C) 2016-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.gradle.osgi;
-
 
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
@@ -38,7 +37,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.bundling.Jar;
@@ -150,8 +149,8 @@ public class BndManifestPlugin extends ProjectPlugin {
 	}
 
 	private static Path outputManifest(Jar jarTask) {
-		JavaPluginConvention javaConvention = jarTask.getProject().getConvention().getPlugin(JavaPluginConvention.class);
-		SourceSet main = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+		JavaPluginExtension javaExtension = jarTask.getProject().getExtensions().getByType(JavaPluginExtension.class);
+		SourceSet main = javaExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 		return main.getOutput().getResourcesDir().toPath().resolve("META-INF/MANIFEST.MF");
 	}
 
@@ -188,8 +187,8 @@ public class BndManifestPlugin extends ProjectPlugin {
 			builder.addClasspath(runtimeConfig);
 
 			// put the class files and resources into the jar
-			JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-			SourceSetOutput main = javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput();
+			JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+			SourceSetOutput main = javaExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput();
 			// delete empty folders so that bnd doesn't make Export-Package entries for them
 			Set<String> includeresource = new LinkedHashSet<>();
 			deleteEmptyFoldersIfExists(main.getResourcesDir());


### PR DESCRIPTION
After creating the PR, please add a commit that adds a bullet-point under the `-SNAPSHOT` section of [CHANGES.md](https://github.com/diffplug/goomph/blob/main/CHANGES.md) that includes:

- [x] a summary of the change
- [x] a link to the newly created PR

- per the issue, gradle 8.2 complains about this. fixes #207 
- i was inspired by https://stackoverflow.com/questions/50860095/how-to-configure-gradle-java-plugin-from-a-custom-gradle-plugin and https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/GroovySourceSet.html
- this project still internally refers to "Convention" but that work seems out of scope of this specific issue (which is to fix the deprecation issues). i'll follow up to see if that work need to be done.

