### PR TITLE
Fix configuration cache issues with the APT plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Added
+- Add Gradle configuration cache compatibility fixes for the Eclipse APT plugin.
 
 ## [4.3.0] - 2025-03-11
 ### Added

--- a/src/main/java/com/diffplug/gradle/eclipse/apt/AptPlugin.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/AptPlugin.java
@@ -109,15 +109,14 @@ public class AptPlugin implements Plugin<Project> {
       final Project project,
       Class<T> compileTaskClass,
       final Function<T, CompileOptions> getCompileOptions) {
-    IMPL.configureTasks(
-        project,
-        compileTaskClass,
-        task -> {
-          CompileOptions compileOptions = getCompileOptions.apply(task);
-          final AptOptions aptOptions = IMPL.createAptOptions();
-          task.getExtensions().add(AptOptions.class, "aptOptions", aptOptions);
-          IMPL.configureCompileTask(task, compileOptions, aptOptions);
-        });
+    project.afterEvaluate(p -> {
+        for (T task : p.getTasks().withType(compileTaskClass)) {
+            CompileOptions compileOptions = getCompileOptions.apply(task);
+            final AptOptions aptOptions = IMPL.createAptOptions();
+            task.getExtensions().add(AptOptions.class, "aptOptions", aptOptions);
+            IMPL.configureCompileTask(task, compileOptions, aptOptions);
+        }
+    });
   }
 
   private <T extends AbstractCompile> void configureCompileTaskForSourceSet(

--- a/src/main/java/com/diffplug/gradle/eclipse/apt/GenerateEclipseFactorypath.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/GenerateEclipseFactorypath.java
@@ -18,7 +18,7 @@ package com.diffplug.gradle.eclipse.apt;
 import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Internal;
 import org.gradle.plugins.ide.api.XmlGeneratorTask;
 
@@ -38,10 +38,10 @@ public class GenerateEclipseFactorypath extends XmlGeneratorTask<Factorypath> {
     EclipseFactorypath factorypathModel = getFactorypath();
     factorypathModel.getFile().getBeforeMerged().execute(factorypath);
     Set<File> entries = new LinkedHashSet<>();
-    for (Configuration configuration : factorypathModel.getPlusConfigurations()) {
+    for (FileCollection configuration : factorypathModel.getPlusConfigurations()) {
       entries.addAll(configuration.getFiles());
     }
-    for (Configuration configuration : factorypathModel.getMinusConfigurations()) {
+    for (FileCollection configuration : factorypathModel.getMinusConfigurations()) {
       entries.removeAll(configuration.getFiles());
     }
     factorypath.mergeEntries(entries);

--- a/src/main/java/com/diffplug/gradle/eclipse/apt/GenerateEclipseJdtApt.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/GenerateEclipseJdtApt.java
@@ -16,12 +16,28 @@
 package com.diffplug.gradle.eclipse.apt;
 
 import java.util.Map;
+
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.Internal;
 import org.gradle.plugins.ide.api.PropertiesGeneratorTask;
+
+import javax.inject.Inject;
 
 public class GenerateEclipseJdtApt extends PropertiesGeneratorTask<JdtApt> {
   @SuppressWarnings("NullAway.Init") // will be initialized by setJdtApt right after creation
   private EclipseJdtApt jdtApt;
+
+  private final ProjectLayout layout;
+
+  @Deprecated
+  public GenerateEclipseJdtApt() {
+    this(null);
+  }
+
+  @Inject
+  public GenerateEclipseJdtApt(ProjectLayout layout) {
+    this.layout = layout != null ? layout : getProject().getLayout();
+  }
 
   @SuppressWarnings("unchecked")
   @Override
@@ -29,8 +45,8 @@ public class GenerateEclipseJdtApt extends PropertiesGeneratorTask<JdtApt> {
     EclipseJdtApt jdtAptModel = getJdtApt();
     jdtAptModel.getFile().getBeforeMerged().execute(jdtApt);
     jdtApt.setAptEnabled(jdtAptModel.isAptEnabled());
-    jdtApt.setGenSrcDir(getProject().relativePath(jdtAptModel.getGenSrcDir()));
-    jdtApt.setGenTestSrcDir(getProject().relativePath(jdtAptModel.getGenTestSrcDir()));
+    jdtApt.setGenSrcDir(layout.getProjectDirectory().file(jdtAptModel.getGenSrcDir().getAbsolutePath()).getAsFile().getPath());
+    jdtApt.setGenTestSrcDir(layout.getProjectDirectory().file(jdtAptModel.getGenTestSrcDir().getAbsolutePath()).getAsFile().getPath());
     jdtApt.setReconcileEnabled(jdtAptModel.isReconcileEnabled());
     jdtApt.getProcessorOptions().clear();
     if (jdtAptModel.getProcessorOptions() != null) {


### PR DESCRIPTION
This PR fixes Gradle 9 errors and configuration cache issues with the APT plugin. This was done by using `@javax.inject.Inject` on some constructors to inject Gradle services into types that could use them, and avoiding the usage of `org.gradle.api.Project` wherever possible.

I'll include some comments on the code itself to help explain some of my changes.

We still use this over at Minecraft Forge, so I'd appreciate it if you could review and merge at your earliest convenience.
