### PR TITLE
Eagerly add AptOptions to compile tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Goomph releases
 
 ## [Unreleased]
+### Fixed
+- Fixed build failure when querying APT options for compile tasks before `project.afterEvaluate`.
 
 ## [4.4.0] - 2025-09-24
 ### Added

--- a/src/main/java/com/diffplug/gradle/eclipse/apt/AptPlugin.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/AptPlugin.java
@@ -109,14 +109,12 @@ public class AptPlugin implements Plugin<Project> {
       final Project project,
       Class<T> compileTaskClass,
       final Function<T, CompileOptions> getCompileOptions) {
-    project.afterEvaluate(p -> {
-        for (T task : p.getTasks().withType(compileTaskClass)) {
-            CompileOptions compileOptions = getCompileOptions.apply(task);
-            final AptOptions aptOptions = IMPL.createAptOptions();
-            task.getExtensions().add(AptOptions.class, "aptOptions", aptOptions);
-            IMPL.configureCompileTask(task, compileOptions, aptOptions);
-        }
-    });
+    for (T task : project.getTasks().withType(compileTaskClass)) {
+        CompileOptions compileOptions = getCompileOptions.apply(task);
+        final AptOptions aptOptions = IMPL.createAptOptions();
+        task.getExtensions().add(AptOptions.class, "aptOptions", aptOptions);
+        IMPL.configureCompileTask(task, compileOptions, aptOptions);
+    }
   }
 
   private <T extends AbstractCompile> void configureCompileTaskForSourceSet(


### PR DESCRIPTION
- Fixes #219.

This PR addresses an oversight in #218 where compile tasks would not have the APT options added to them until project evaluation finishes. Plugins and buildscript authors may need to query these options before then.