### PR TITLE
test: normalize XML before comparison to avoid attribute-order failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [4.4.2] - 2025-11-06
+### Fixed
+- Changed CleanedAssert assertion to pass when attributes aren't in the correct order by normalizing XML content before comparison. Fixes test failures when running tests in P2ModelTest with Nondex due to non-deterministic attribute ordering in tags resulting from mirrorApp. ([#222](https://github.com/diffplug/goomph/pull/222))
+
 ## [4.4.1] - 2025-10-15
 ### Fixed
 - Fixed build failure when querying APT options for compile tasks before `project.afterEvaluate`.

--- a/HOW_TO_AUTOMATE_IDE.md
+++ b/HOW_TO_AUTOMATE_IDE.md
@@ -11,7 +11,7 @@ So you want to automate your IDE configuration.  The first thing to do is look a
 - [Spotless](https://github.com/diffplug/spotless/blob/gradle/5.17.1/ide/build.gradle) (single-project Gradle plugin)
 - (your example here)
 
-The next thing is to look at the [javadoc](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/oomph/OomphIdePlugin.html) for `OomphIdePlugin`, which inclues a pretty in-depth look at how it works.
+The next thing is to look at the [javadoc](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/oomph/OomphIdePlugin.html) for `OomphIdePlugin`, which inclues a pretty in-depth look at how it works.
 
 ## How do I automate ${MY_THING} which isn't in the examples or docs?
 
@@ -27,7 +27,7 @@ Depending on what you're trying to automate, you might need to touch all three.
 
 Manipulating project files is a [core part of gradle](https://docs.gradle.org/current/userguide/eclipse_plugin.html), so we won't cover that here.
 
-Manipulating plugin and feature jars has lots of coverage in the examples above.  The entire `oomphIdeBlock` extends [P2Declarative](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/P2Declarative.html).
+Manipulating plugin and feature jars has lots of coverage in the examples above.  The entire `oomphIdeBlock` extends [P2Declarative](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/P2Declarative.html).
 So if you want to add any features, you just add the required p2 repositories, and then specify the features or installable units that you need.
 
 Manipulating the workspace is where it gets tricky.  We'll dig in below:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ output = [
 [![Maven artifact](https://img.shields.io/badge/mavenCentral-com.diffplug.gradle%3Agoomph-blue.svg)](https://search.maven.org/artifact/com.diffplug.gradle/goomph)
 [![License Apache](https://img.shields.io/badge/license-Apache-blue.svg)](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 
-[![Changelog](https://img.shields.io/badge/changelog-4.4.1-brightgreen.svg)](CHANGES.md)
-[![Javadoc](https://img.shields.io/badge/javadoc-yes-brightgreen.svg)](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/index.html)
+[![Changelog](https://img.shields.io/badge/changelog-4.4.2-brightgreen.svg)](CHANGES.md)
+[![Javadoc](https://img.shields.io/badge/javadoc-yes-brightgreen.svg)](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/index.html)
 [![Live chat](https://img.shields.io/badge/gitter-live_chat-brightgreen.svg)](https://gitter.im/diffplug/goomph)
 [![CircleCI](https://circleci.com/gh/diffplug/goomph.svg?style=shield)](https://circleci.com/gh/diffplug/goomph)
 <!---freshmark /shields -->
@@ -48,38 +48,38 @@ Below is an index of Goomph's capabilities, along with links to the javadoc wher
 
 #### `com.diffplug.eclipse` Eclipse project files and eclipse version-mapping maven central artifacts.
 
-* [`apt`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipse/apt/AptEclipsePlugin.html) fixes eclipse project to work with Gradle annotation processing.
-* [`mavencentral`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipse/MavenCentralPlugin.html) makes it easy to add dependency jars from an eclipse release.
-* [`buildproperties`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipse/BuildPropertiesPlugin.html) uses [`build.properties`](https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fguide%2Ftools%2Feditors%2Fmanifest_editor%2Fbuild.htm) to control a gradle build, and fixes eclipse project classpath to include binary assets specified in `build.properties`.
-* [`excludebuildfolder`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipse/ExcludeBuildFolderPlugin.html) excludes the gradle `build` folder from Eclipse's resource indexing.
-* [`projectdeps`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipse/ProjectDepsPlugin.html) fixes an intermittent problem where dependencies on other projects within the workspace aren't always resolved correctly within Eclipse.
-* [`resourcefilters`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipse/ResourceFiltersPlugin.html) adds resource filters to the eclipse project.
+* [`apt`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipse/apt/AptEclipsePlugin.html) fixes eclipse project to work with Gradle annotation processing.
+* [`mavencentral`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipse/MavenCentralPlugin.html) makes it easy to add dependency jars from an eclipse release.
+* [`buildproperties`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipse/BuildPropertiesPlugin.html) uses [`build.properties`](https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fguide%2Ftools%2Feditors%2Fmanifest_editor%2Fbuild.htm) to control a gradle build, and fixes eclipse project classpath to include binary assets specified in `build.properties`.
+* [`excludebuildfolder`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipse/ExcludeBuildFolderPlugin.html) excludes the gradle `build` folder from Eclipse's resource indexing.
+* [`projectdeps`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipse/ProjectDepsPlugin.html) fixes an intermittent problem where dependencies on other projects within the workspace aren't always resolved correctly within Eclipse.
+* [`resourcefilters`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipse/ResourceFiltersPlugin.html) adds resource filters to the eclipse project.
 
 #### `com.diffplug.osgi` Plugins for working with OSGi.
 
-* [`bndmanifest`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/osgi/BndManifestPlugin.html) generates a manifest using purely bnd, and outputs it for IDE consumption.
-* [`equinoxlaunch`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/eclipserunner/EquinoxLaunchPlugin.html) can configure and run equinox applications as part of the build, such as a code generator.
-* [`OsgiExecable`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/osgi/OsgiExecable.html) makes it easy to run a chunk of code within an OSGi container, and get the result from outside the container.
+* [`bndmanifest`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/osgi/BndManifestPlugin.html) generates a manifest using purely bnd, and outputs it for IDE consumption.
+* [`equinoxlaunch`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/eclipserunner/EquinoxLaunchPlugin.html) can configure and run equinox applications as part of the build, such as a code generator.
+* [`OsgiExecable`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/osgi/OsgiExecable.html) makes it easy to run a chunk of code within an OSGi container, and get the result from outside the container.
 
 #### `com.diffplug.p2` A  and plugins for manipulating p2 data. (*mostly [abandoned](https://github.com/diffplug/goomph/issues/166#issuecomment-945188596) now*)
 
-* [`asmaven`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/AsMavenPlugin.html) downloads dependencies from a p2 repository and makes them available in a local maven repository.
-* [`P2Model`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/P2Model.html) models a set of p2 repositories and IUs, and provides convenience methods for running p2-director or the p2.mirror ant task against these.
-* [`P2AntRunner`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/P2AntRunner.html) runs eclipse ant tasks.
-* [`CategoryPublisher`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/CategoryPublisher.html) models the CategoryPublisher eclipse application.
-* [`FeaturesAndBundlesPublisher`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/FeaturesAndBundlesPublisher.html) models the FeaturesAndBundlesPublisher eclipse application.
-* [`Repo2Runnable`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/p2/Repo2Runnable.html) models the Repo2Runnable eclipse application.
+* [`asmaven`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/AsMavenPlugin.html) downloads dependencies from a p2 repository and makes them available in a local maven repository.
+* [`P2Model`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/P2Model.html) models a set of p2 repositories and IUs, and provides convenience methods for running p2-director or the p2.mirror ant task against these.
+* [`P2AntRunner`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/P2AntRunner.html) runs eclipse ant tasks.
+* [`CategoryPublisher`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/CategoryPublisher.html) models the CategoryPublisher eclipse application.
+* [`FeaturesAndBundlesPublisher`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/FeaturesAndBundlesPublisher.html) models the FeaturesAndBundlesPublisher eclipse application.
+* [`Repo2Runnable`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/p2/Repo2Runnable.html) models the Repo2Runnable eclipse application.
 
 #### `com.diffplug.gradle.pde` Tasks for running Eclipse PDE using a downloaded eclipse instance. (*this part is mostly [abandoned](https://github.com/diffplug/goomph/issues/166#issuecomment-945188596) now*)
 
-* [`PdeBuildTask`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/pde/PdeBuildTask.html) runs PDE build to build an RCP product.
-* [`PdeAntBuildTask`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/pde/PdeAntBuildTask.html) runs PDE on an ant file.
+* [`PdeBuildTask`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/pde/PdeBuildTask.html) runs PDE build to build an RCP product.
+* [`PdeAntBuildTask`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/pde/PdeAntBuildTask.html) runs PDE on an ant file.
 
 #### `com.diffplug.gradle` Miscellaneous infrastructure.
 
-* [`CmdLineTask`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/CmdLineTask.html) runs a series of shell commands, possibly copying or moving files in the meantime.
-* [`JavaExecable`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/JavaExecable.html) makes it easy to run a chunk of code in a separate JVM, and get the result back in this one.
-* [`JavaExecWinFriendly`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/JavaExecWinFriendly.html) overcomes limitations in Windows' commandline length and long classpaths.
+* [`CmdLineTask`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/CmdLineTask.html) runs a series of shell commands, possibly copying or moving files in the meantime.
+* [`JavaExecable`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/JavaExecable.html) makes it easy to run a chunk of code in a separate JVM, and get the result back in this one.
+* [`JavaExecWinFriendly`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/JavaExecWinFriendly.html) overcomes limitations in Windows' commandline length and long classpaths.
 
 #### `com.diffplug.gradle.eclipserunner` Infrastructure for running headless eclipse applications.
 
@@ -87,7 +87,7 @@ Below is an index of Goomph's capabilities, along with links to the javadoc wher
 
 #### Other
 
-* [`com.diffplug.configuration-cache-for-platform-specific-build`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/swt/PlatformSpecificBuildPlugin.html) allows you to use `OS.getNative()` and `OS.getRunning()` in your gradle build without breaking the configuration cache.
+* [`com.diffplug.configuration-cache-for-platform-specific-build`](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/swt/PlatformSpecificBuildPlugin.html) allows you to use `OS.getNative()` and `OS.getRunning()` in your gradle build without breaking the configuration cache.
 
 ## IDE-as-build-artifact. (*this part is mostly [abandoned](https://github.com/diffplug/goomph/issues/189)*)
 
@@ -110,7 +110,7 @@ oomphIde {
 }
 ```
 
-See the [plugin's javadoc](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.1/com/diffplug/gradle/oomph/OomphIdePlugin.html) for a quickstart, and [HOW_TO_AUTOMATE_IDE.md](HOW_TO_AUTOMATE_IDE.md) for examples and more in-depth details.
+See the [plugin's javadoc](https://javadoc.io/doc/com.diffplug.gradle/goomph/4.4.2/com/diffplug/gradle/oomph/OomphIdePlugin.html) for a quickstart, and [HOW_TO_AUTOMATE_IDE.md](HOW_TO_AUTOMATE_IDE.md) for examples and more in-depth details.
 
 <!---freshmark /javadoc -->
 

--- a/src/main/java/com/diffplug/gradle/p2/P2Model.java
+++ b/src/main/java/com/diffplug/gradle/p2/P2Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 DiffPlug
+ * Copyright (C) 2015-2025 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.gradle.p2;
-
 
 import com.diffplug.common.base.Consumers;
 import com.diffplug.common.base.Errors;


### PR DESCRIPTION
## Purpose of this PR
This PR makes XML comparisons in tests deterministic by normalizing attribute order before asserting equality.
When running tests under [NonDex](https://github.com/TestingResearchIllinois/NonDex), XML attributes may appear in different orders, causing false test failures even though the XML content is equivalent. This is likely due to the use of a hashMap in `completeState()` in `EclipseApp.java` when 
```java
args.asMap().forEach((key, values) -> {
```
is used to build the XML string, and the use of hashMaps in `mirrorApp` in `P2Model.java`
```java
destination.attributes().put("location", ...)
destination.attributes().put("append", append);
...
iuNode.attributes().put("id", ...)
iuNode.attributes().put("version", ...)
```
from calling `.attributes()`, as HashMaps do not guarantee the order of key value pairs over time.
This class is confirmed when adding the following lines to `mirrorApp` : 
```java
System.out.println("destination attributes class = " + destination.attributes().getClass());
System.out.println("iuNode attributes class = " + iuNode.attributes().getClass());
```
This change ensures the XML tests fail only when there is a real XML mismatch, not due to nondeterministic attribute ordering.

## What the PR changes
- Replaces:
```java
Assert.assertEquals(trim(expected), trim(actual));
```
with
```java
Assert.assertEquals(normalizeXml(trim(expected)), normalizeXml(trim(actual)));
```
- Adds `normalizeXml` to `CleanedAssert.java`, which:
    - detects XML tags
    - extracts all attributes
    - sorts attributes alphabetically
    - reconstructs the normalized XML string for comparison
This ensures that 
```
<repo kind="meta" location="url"/>
```
and
```
<repo location="url" kind="meta"/>
```
are treated as equal in tests

## Results
- Eliminates nondeterministic test failures under Nondex
- Makes test suite deterministic and stable across environments
- Improves confidence in XML-based tests by focusing on real semantic differences
- Enhances reliability of CI pipeline when randomness is instroduced

## Steps to reproduce original Failure
1) Add the following to `plugins` in `build.gradle`: `id 'edu.illinois.nondex' version '2.1.7'`
2) Add the following to the bottom of `build.gradle`: `apply plugin: 'edu.illinois.nondex'`
3) Change 
```
test {
	if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
		jvmArgs '--add-modules=ALL-SYSTEM', '--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED'
	}
	testLogging.exceptionFormat = 'full'
}
```
to 
```
tasks.withType(Test).configureEach {
    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
        jvmArgs '--add-modules=ALL-SYSTEM', '--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED'
    }
    testLogging {
        exceptionFormat = 'full'
        events "passed", "failed", "skipped", "standardOut", "standardError"
        showStandardStreams = true
    }
}
```
4) Run `./gradlew nondexTest --tests "com.diffplug.gradle.p2.P2ModelTest.testMirrorAntFile"`, 
`./gradlew nondexTest --tests "com.diffplug.gradle.p2.P2ModelTest.testMirrorAntFileWithAppend"`, 
`./gradlew nondexTest --tests "com.diffplug.gradle.p2.P2ModelTest.testMirrorAntFileWithAppenDefault"`, 
and `./gradlew nondexTest --tests "com.diffplug.gradle.p2.P2ModelTest.testMirrorAntFileWithSlicingOptions"` in the terminal
- there should be output similar to what is shown below: 
```
P2ModelTest > testMirrorAntFile FAILED
    org.junit.ComparisonFailure: expected:<...repo"/>
    <repository [kind="metadata" location="https://metadatarepo"/>
    <repository kind="artifact" location="https://artifactrepo"/>
    </source>
    <destination location="file:///home/lw41/progress_report_4/goomph/dest" append="false"/>
    <iu id="com.diffplug.iu"/>
    <iu id="com.diffplug.otheriu" version="1.0.0]"/>
    </p2.mirror>
    </p...> but was:<...repo"/>
    <repository [location="https://metadatarepo" kind="metadata"/>
    <repository location="https://artifactrepo" kind="artifact"/>
    </source>
    <destination append="false" location="file:///home/lw41/progress_report_4/goomph/dest"/>
    <iu id="com.diffplug.iu"/>
    <iu version="1.0.0" id="com.diffplug.otheriu]"/>
    </p2.mirror>
    </p...>
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at com.diffplug.gradle.CleanedAssert.xml(CleanedAssert.java:31)
        at com.diffplug.gradle.p2.P2ModelTest.testMirrorAntFile(P2ModelTest.java:79)
```
