### PR TITLE
#221 Fix setting getTestSrcDir

### DIFF
--- a/src/main/java/com/diffplug/gradle/eclipse/apt/EclipseJdtApt.java
+++ b/src/main/java/com/diffplug/gradle/eclipse/apt/EclipseJdtApt.java
@@ -114,7 +114,7 @@ public class EclipseJdtApt {
 
   public void setGenTestSrcDir(Object genTestSrcDir) {
     Objects.requireNonNull(genTestSrcDir);
-    this.genSrcDir.set(providers.provider(() -> layout.getProjectDirectory().files(genTestSrcDir).getSingleFile()));
+    this.genTestSrcDir.set(providers.provider(() -> layout.getProjectDirectory().files(genTestSrcDir).getSingleFile()));
   }
 
   // XXX: this is actually either a Property<Map> or a MapProperty depending on Gradle version


### PR DESCRIPTION
Simple fix to allow setting the genTestSrcDir property with a lazy provider/property
